### PR TITLE
fix: make hero section responsive on mobile (#28)

### DIFF
--- a/.vitepress/components/HomePage.vue
+++ b/.vitepress/components/HomePage.vue
@@ -198,6 +198,14 @@ const icons = {
 
 .hero-content {
   max-width: 540px;
+  min-width: 0;
+}
+
+.hero-visual {
+  /* Allow the grid track to shrink below its min-content so the unwrapping
+     <pre> code line below can't force the hero (and page) wider than the
+     viewport. See https://github.com/fontist/fontist.github.io/issues/28 */
+  min-width: 0;
 }
 
 .hero-badge {
@@ -314,6 +322,9 @@ const icons = {
   font-size: 0.875rem;
   line-height: 1.7;
   color: rgba(255, 255, 255, 0.9);
+  /* <pre> never wraps; let long commands scroll inside the box instead of
+     forcing the hero column (and the page) wider. See issue #28. */
+  overflow-x: auto;
 }
 
 .code-content code {


### PR DESCRIPTION
## Summary

Fixes #28 — the hero area was pushing the page out sideways on mobile (~245 px of horizontal overflow at 375 px width).

## Root cause

The hero is a two-column CSS grid:

```css
.hero { display: grid; grid-template-columns: 1fr 1fr; }
``\}

`1fr 1fr` expands to `minmax(auto, 1fr)`. The `auto` minimum tracks the **min-content** of the grid item `.hero-visual`, which contains a `<pre>` terminal preview. Because `<pre>` never wraps, its longest line —

```
$ fontisan convert --to woff2 ~/.fontist/fonts/Roboto-Regular.ttf
```

— has a min-content of ~596 px. That became the grid track's automatic minimum, so even at mobile widths the track (and therefore the hero, and therefore the page) could not shrink below ~596 px → horizontal page overflow.

## Fix

Two complementary scoped-CSS changes in [`.vitepress/components/HomePage.vue`](`.vitepress/components/HomePage.vue`):

1. **`min-width: 0`** on `.hero-content` and `.hero-visual` — lets the grid tracks shrink below their min-content (the canonical CSS grid gotcha fix).
2. **`overflow-x: auto`** on `.code-content` — long commands now scroll *inside* the terminal box instead of stretching the column.

No template / markup / TS changes — pure scoped CSS.

## Verification (Playwright, real browser)

Measured `document.documentElement.scrollWidth` vs `window.innerWidth`:

| Viewport | Before | After |
|---|---|---|
| 375 px (iPhone) | 620 px (**+245 px overflow**) | 360 px (**no overflow**) |
| 414 px (large phone) | — | 399 px (no overflow) |
| 1280 px (desktop) | — | 1265 px (no overflow, two-column hero preserved) |

`.hero-visual` correctly resizes from 596 px (broken) → 312 px (fixed) at 375 px. The long terminal line now scrolls inside its box on narrow viewports. `npm run build` passes.

Fixes #28