### PR TITLE
feat: enable SEO baseline (sitemap, robots.txt, page meta)

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -12,6 +12,11 @@ export default defineConfig({
 
   lastUpdated: true,
 
+  // https://vitepress.dev/reference/site-config#sitemap
+  sitemap: {
+    hostname: "https://www.fontist.org",
+  },
+
   // https://github.com/vuejs/vitepress/issues/3508
   base: process.env.BASE_PATH,
 
@@ -30,7 +35,7 @@ export default defineConfig({
         content: "Install openly-licensed fonts on Windows, Linux and Mac!",
       },
     ],
-    ["meta", { property: "og:image", content: "/logo-full.svg" }],
+    ["meta", { property: "og:image", content: "https://www.fontist.org/logo-full.svg" }],
     ["meta", { name: "twitter:card", content: "summary_large_image" }],
   ],
 

--- a/blog/index.md
+++ b/blog/index.md
@@ -1,4 +1,6 @@
 ---
+title: Fontist Blog
+description: Updates, releases, and guides from the Fontist project on cross-platform font management for automated systems and digital publishing.
 outline: false
 ---
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.fontist.org/sitemap.xml


### PR DESCRIPTION
## Summary

Enables the standard SEO surface for the site so pages are discoverable and crawlable by search engines and social crawlers.

## Changes

| File | Change |
|---|---|
| [`.vitepress/config.ts`](.vitepress/config.ts) | Enable VitePress `sitemap` (`hostname: https://www.fontist.org`); make `og:image` absolute |
| [`public/robots.txt`](public/robots.txt) | **New** — allow-all + sitemap reference (served at site root) |
| [`blog/index.md`](blog/index.md) | Add `title`/`description` — the only content page lacking page-level meta |

## On "SSG"

VitePress is **already** an SSG — `npm run build` pre-renders every route (`blog/*`, `integrations/*`, `index`, `about`) to `.vitepress/dist/*.html`, deployed via GitHub Pages. There was nothing to enable for SSG; the actionable work was SEO (sitemap + robots + meta), which is what makes the already-static pages crawlable.

## Verification

`npm run build` passes and the log shows `✓ generating sitemap...`. Confirmed in `.vitepress/dist/`:

- ✅ `sitemap.xml` — 13 URLs with absolute `https://www.fontist.org/...` locs + lastmod (home, about, blog index, 8 blog posts, integrations/github-actions, README)
- ✅ `robots.txt` — `User-agent: *` / `Allow: /` / `Sitemap: https://www.fontist.org/sitemap.xml`
- ✅ `blog/index.html` — now carries `<meta name="description">`

## Follow-ups (not in this PR)

- **Per-page Open Graph tags** (`og:title`/`og:description` from each page's frontmatter) — currently the head config is site-wide. Would need a `transformHead` hook or per-page frontmatter `head`.
- **PNG og:image** — `logo-full.svg` is absolute now, but SVG has poor support on Twitter/Facebook; a 1200×630 PNG would render richer social cards.
- **JSON-LD structured data** for blog posts.