### PR TITLE
fix: subsite links (/fontist/, /fontisan/, /formulas/) SPA-404 from homepage + CI guard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Verify subsite links bypass SPA router
+        run: npm run check:subsite-links
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:

--- a/.vitepress/components/HomePage.vue
+++ b/.vitepress/components/HomePage.vue
@@ -61,7 +61,11 @@ const icons = {
           Designed for automated systems, CI/CD pipelines, and digital publishing.
         </p>
         <div class="hero-actions">
-          <a href="https://www.fontist.org/fontist/" class="btn btn-primary">
+          <!-- target="_self" is mandatory on links to the separately-deployed
+               subsites (/fontist/, /fontisan/, /formulas/): without a target
+               attribute, VitePress's SPA router intercepts same-origin clicks
+               and renders its own 404. Enforced by scripts/check-subsite-links.mjs. -->
+          <a href="https://www.fontist.org/fontist/" target="_self" class="btn btn-primary">
             Get Started
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <path d="M5 12h14M12 5l7 7-7 7"/>
@@ -103,7 +107,7 @@ const icons = {
           @mouseenter="hoveredCard = product.id"
           @mouseleave="hoveredCard = null"
         >
-          <a :href="product.link" class="card-link">
+          <a :href="product.link" target="_self" class="card-link">
             <div class="card-icon">
               <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" v-html="icons[product.icon as keyof typeof icons]" />
             </div>

--- a/about.md
+++ b/about.md
@@ -217,11 +217,11 @@ Fontist is proudly open source. We believe font management infrastructure should
 Ready to use Fontist in your automated workflows?
 
 <div class="get-started-links">
-  <a href="https://www.fontist.org/fontist/" class="gs-link gs-link-primary">
+  <a href="https://www.fontist.org/fontist/" target="_self" class="gs-link gs-link-primary">
     <span class="gs-title">Documentation</span>
     <span class="gs-desc">Learn how to install and use Fontist</span>
   </a>
-  <a href="https://www.fontist.org/formulas/" class="gs-link">
+  <a href="https://www.fontist.org/formulas/" target="_self" class="gs-link">
     <span class="gs-title">Browse Formulas</span>
     <span class="gs-desc">Explore 2,000+ available fonts</span>
   </a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "devDependencies": {
         "@types/node": "^25.4.0",
+        "node-html-parser": "^7.0.1",
         "prettier": "^3.8.1",
         "typescript": "^5.9.3",
         "vitepress": "^1.6.4"
@@ -1606,6 +1607,13 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ccount": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -1666,6 +1674,36 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1695,6 +1733,78 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/emoji-regex-xs": {
@@ -1824,6 +1934,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/hookable": {
@@ -2021,6 +2141,30 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-html-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.1.0.tgz",
+      "integrity": "sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/oniguruma-to-es": {

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
     "dev": "vitepress dev",
     "build": "vitepress build",
     "preview": "vitepress preview",
-    "format": "prettier -w ."
+    "format": "prettier -w .",
+    "check:subsite-links": "node scripts/check-subsite-links.mjs"
   },
   "type": "module",
   "devDependencies": {
     "@types/node": "^25.4.0",
+    "node-html-parser": "^7.0.1",
     "prettier": "^3.8.1",
     "typescript": "^5.9.3",
     "vitepress": "^1.6.4"

--- a/scripts/check-subsite-links.mjs
+++ b/scripts/check-subsite-links.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// Post-build invariant check.
+//
+// /fontist/, /fontisan/, and /formulas/ are served by SEPARATE GitHub Pages
+// repos (fontist/fontist, fontist/fontisan, fontist/formulas), not by this
+// VitePress build. Links to them MUST trigger a full page load (server
+// round-trip), otherwise VitePress's SPA router intercepts the click, fails
+// to find the route, and renders its own 404 page.
+//
+// VitePress's router (node_modules/vitepress/dist/client/app/router.js)
+// skips a link iff the <a> has a `target` attribute:
+//
+//     if (link.hasAttribute('target')) return;   // line ~134
+//
+// So this script enforces the proxy: every <a> in the built site whose href
+// resolves (same-origin) to a subsite path must carry a `target` attribute.
+// Run after `npm run build`. Fails the build (and thus the deploy) on regression.
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { parse } from "node-html-parser";
+
+const SITE_ORIGIN = "https://www.fontist.org";
+const SUBSITE_PATHS = ["/fontist", "/fontisan", "/formulas"];
+const DIST_DIR = ".vitepress/dist";
+
+function isSubsitePath(pathname) {
+  // Normalize /fontist, /fontist/, /fontist/index.html, /fontist/foo.html → /fontist/…
+  const clean = pathname.replace(/\/index\.html$/, "/").replace(/\.html$/, "");
+  return SUBSITE_PATHS.some(
+    (sp) => clean === sp || clean.startsWith(sp + "/"),
+  );
+}
+
+function walkHtml(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) walkHtml(full, out);
+    else if (entry.endsWith(".html")) out.push(full);
+  }
+  return out;
+}
+
+const offenders = [];
+for (const file of walkHtml(DIST_DIR)) {
+  const root = parse(readFileSync(file, "utf8"));
+  for (const a of root.querySelectorAll("a")) {
+    const href = a.getAttribute("href");
+    if (!href) continue;
+    let url;
+    try {
+      url = new URL(href, SITE_ORIGIN);
+    } catch {
+      continue; // non-url hrefs (anchors, mailto, etc.) — not our concern
+    }
+    if (url.origin === SITE_ORIGIN && isSubsitePath(url.pathname)) {
+      const target = a.getAttribute("target");
+      if (!target) {
+        const rel = file.replace(DIST_DIR + "/", "");
+        offenders.push(
+          `${rel}: <a href="${href}"> has no target attribute — SPA router will intercept and 404`,
+        );
+      }
+    }
+  }
+}
+
+if (offenders.length > 0) {
+  console.error(
+    "✗ subsite-link check failed. Add target=\"_self\" to each offending <a>:\n",
+  );
+  console.error(offenders.map((o) => "  " + o).join("\n"));
+  process.exit(1);
+}
+
+console.log(
+  "✓ all subsite links carry a target attribute (bypass VitePress SPA router)",
+);


### PR DESCRIPTION
Fixes the production regression where navigating from fontist.org to the separately-deployed subsites (`/fontist/`, `/fontisan/`, `/formulas/`) returned a VitePress 404 page, and adds a CI guard so it can't recur.

## Root cause

`/fontist/`, `/fontisan/`, and `/formulas/` are served by **separate** GitHub Pages repos (`fontist/fontist`, `fontist/fontisan`, `fontist/formulas`), not by this VitePress build. A direct load (refresh / URL entry) hits the server → 200 (works). But clicking a link from the homepage was intercepted by **VitePress's SPA router**, which has no `/fontist/` route → it renders its own 404 page client-side.

`node_modules/vitepress/dist/client/app/router.js`:

```js
const link = e.target.closest('a');
if (link.hasAttribute('target')) return;          // ← only skips if <a> has target
const { origin, pathname } = new URL(linkHref, link.baseURI);
if (origin === currentUrl.origin && treatAsHtml(pathname)) {
  e.preventDefault();                              // ← SPA-intercept same-origin links
}
```

The **nav** links had `target="_self"` (via config) → router skipped → full reload → worked. But `HomePage.vue` and `about.md` rendered plain `<a href="https://www.fontist.org/fontist/">` with **no** `target` → intercepted → SPA 404.

## The fix

Add `target="_self"` to every subsite `<a>`:

| File | Links fixed |
|---|---|
| `.vitepress/components/HomePage.vue` | hero "Get Started" + 3 product-card links |
| `about.md` | "Documentation" + "Browse Formulas" in the Get Started block |

This is the same mechanism the nav already uses. With `target` present, the router skips interception and the browser does a full page load to the subsite (200).

## The guard (so it never happens again)

`scripts/check-subsite-links.mjs` — a post-build check that walks `.vitepress/dist/*.html` and **fails** if any `<a>` resolving (same-origin) to `/fontist/`, `/fontisan/`, or `/formulas/` lacks a `target` attribute. It enforces the exact bypass condition the router uses (`link.hasAttribute('target')`).

Wired into `.github/workflows/build.yml` between **Build** and **Upload-artifact** — a missing `target` fails the build job and blocks the Pages deploy. Uses `node-html-parser` (new devDep) for robust DOM querying.

### TDD verification (red → green)

Pre-fix (current `main`):
```
✗ subsite-link check failed. Add target="_self" to each offending <a>:
  about.html:    <a href="https://www.fontist.org/fontist/">  — SPA router will intercept and 404
  about.html:    <a href="https://www.fontist.org/formulas/"> — SPA router will intercept and 404
  index.html:    <a href="https://www.fontist.org/fontist/">  — SPA router will intercept and 404  (hero)
  index.html:    <a href="https://www.fontist.org/fontist/">  — SPA router will intercept and 404  (card)
  index.html:    <a href="https://www.fontist.org/fontisan/">— SPA router will intercept and 404  (card)
  index.html:    <a href="https://www.fontist.org/formulas/"> — SPA router will intercept and 404  (card)
```

Post-fix:
```
✓ all subsite links carry a target attribute (bypass VitePress SPA router)
```

(The pre-existing nav links — which always carried `target` via config — were never flagged.)

## Runtime confirmation of the mechanism

Reproduced on live before fixing: clicking the hero "Get Started" from `fontist.org` ended at `https://www.fontist.org/fontist/` with `<title>404 | Fontist</title>`, while a server-side `curl` of the same URL returned **HTTP 200** with `<title>Fontist</title>` — confirming the 404 is purely a client-side SPA artifact, not a server problem.

## Commits

1. `fix:` add `target=_self` to subsite links (HomePage.vue + about.md)
2. `ci:` post-build guard + wire into build.yml (scripts/ + workflow + dep)
