### PR TITLE
fix: resolve /about/ (trailing slash) 404 on GitHub Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dev": "vitepress dev",
-    "build": "vitepress build",
+    "build": "vitepress build && node scripts/dirify-urls.mjs",
     "preview": "vitepress preview",
     "format": "prettier -w .",
     "check:subsite-links": "node scripts/check-subsite-links.mjs"

--- a/scripts/dirify-urls.mjs
+++ b/scripts/dirify-urls.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// Convert VitePress file-style output (about.html) into directory-style
+// (about/index.html) so GitHub Pages resolves BOTH /about and /about/.
+//
+// VitePress `cleanUrls: true` builds about.md -> about.html and emits links
+// like /about. GitHub Pages serves /about -> about.html (200) but /about/ ->
+// about/index.html (404, because about.html is a file, not a directory).
+// Moving each non-index *.html to <name>/index.html makes both forms resolve.
+//
+// Kept at the dist root:
+//   - index.html   (the site root)
+//   - 404.html     (GitHub Pages serves /404.html as the site-wide 404 page)
+//
+// Idempotent: safe to run repeatedly.
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  renameSync,
+  statSync,
+} from "node:fs";
+import { join } from "node:path";
+
+const DIST = ".vitepress/dist";
+const HTML = ".html";
+const KEEP_AT_ROOT = new Set(["index.html", "404.html"]);
+
+let moved = 0;
+let skipped = 0;
+
+function dirify(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      dirify(full);
+      continue;
+    }
+    if (!entry.endsWith(HTML)) continue;
+    if (entry === "index.html") continue; // already directory-style
+    if (dir === DIST && KEEP_AT_ROOT.has(entry)) {
+      skipped++; // root index.html / 404.html stay put
+      continue;
+    }
+    const name = entry.slice(0, -HTML.length);
+    const targetDir = join(dir, name);
+    const targetIndex = join(targetDir, "index.html");
+    if (existsSync(targetIndex)) {
+      console.warn(
+        `[dirify] skip ${full.replace(DIST + "/", "")}: target index.html already exists`,
+      );
+      skipped++;
+      continue;
+    }
+    mkdirSync(targetDir, { recursive: true });
+    renameSync(full, targetIndex);
+    moved++;
+  }
+}
+
+dirify(DIST);
+console.log(
+  `[dirify] moved ${moved} file-route(s) to directory form, kept ${skipped} at root`,
+);


### PR DESCRIPTION
Fixes `/about/` (and every other file-route) returning **404** on a trailing-slash URL — e.g. the nav "About" link, blog-post share links, any external link to `fontist.org/about/`.

## Root cause

VitePress `cleanUrls: true` builds `about.md` → `about.html` (a **file**). GitHub Pages resolves `/about/` (trailing slash) as `about/index.html` (a **directory**) → not found → **404**. `/about` (no slash) only worked because GHP falls through to `about.html`.

| URL | Before | After |
|---|---|---|
| `/about/` | **404** | **200** |
| `/about` | 200 | 200 |
| `/blog/2026-04-14-formula-v5/` | 404 | 200 |

## Fix

`scripts/dirify-urls.mjs` runs after `vitepress build` (now wired into the `build` npm script) and moves each non-index `*.html` to `<name>/index.html`, so both URL forms resolve. Idempotent.

- `about.html` → `about/index.html`
- `blog/<post>.html` → `blog/<post>/index.html`
- `integrations/github-actions.html` → `integrations/github-actions/index.html`
- `README.html` → `README/index.html`
- **Kept at root:** `index.html` (site root) and `404.html` (GHP serves `/404.html` as the site-wide 404 page).

Affects 11 file-routes.

## Local verification

- `npm run build` → `[dirify] moved 11 file-routes to directory form, kept 1 at root` (the 1 = `404.html`).
- `vitepress preview`: `/about/` **200**, `/about` **200**, `/blog/2026-04-14-formula-v5/` **200**, served the real "About Fontist" page (not the 404 page).
- SPA nav still works: clicking the "About" nav item renders `About Fontist | Fontist` (no 404) — dirify only relocates HTML shells, the page-data chunks under `assets/` are untouched.
- The subsite-link guard (`scripts/check-subsite-links.mjs`) still passes on the dirified dist.

## Not in scope

This fixes the trailing-slash 404. It does not add canonical URL tags to dedupe `/about` vs `/about/` for SEO (minor, both now resolve to identical content) — happy to follow up if you want that.
