### PR TITLE
cleanup: remove dead code + fix stale font references

### DIFF
--- a/.vitepress/components/HomePage.vue
+++ b/.vitepress/components/HomePage.vue
@@ -17,7 +17,7 @@ const openSourceCount = formulaData.openSourceCount;
 const specimens = [
   {
     name: "Spectral",
-    cssFamily: "'Fraunces', Georgia, serif",
+    cssFamily: "'Spectral', Georgia, serif",
     install: 'fontist install "Spectral"',
     note: "Display serif · variable opsz",
   },
@@ -257,7 +257,7 @@ onUnmounted(() => { if (typeTimer) clearTimeout(typeTimer); });
 
     <!-- Footer colophon -->
     <footer class="foot">
-      <span>Set in <em>Fraunces</em>, <em>IBM&nbsp;Plex</em>, &amp; <em>JetBrains&nbsp;Mono</em>.</span>
+      <span>Set in <em>Spectral</em>, <em>IBM&nbsp;Plex</em>, &amp; <em>JetBrains&nbsp;Mono</em>.</span>
       <span class="r">Fontist · a Ribose project · © MMXXVI</span>
     </footer>
   </div>

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -426,13 +426,6 @@ html.dark .vp-doc [class*="language-"] {
   font-size: 13px;
 }
 
-/* ── Homepage palette (pageClass: specimen-home) ──────────────── */
-/* Specimen tokens are now global (above); the pageClass remains on
-   index.md for any homepage-only tweaks, but inherits the system. */
-.specimen-home {
-  background-color: var(--spec-paper);
-}
-
 /* ── 404 page — specimen ───────────────────────────────────────── */
 .NotFound {
   text-align: center;

--- a/index.md
+++ b/index.md
@@ -2,7 +2,6 @@
 layout: page
 title: Fontist - Cross-Platform Font Management
 description: Install, manage, and build fonts programmatically across Windows, Linux, and macOS. Designed for automated systems and digital publishing.
-pageClass: specimen-home
 ---
 
 <HomePage />


### PR DESCRIPTION
Post-merge cleanup after PR #42 (specimen redesign). Three items:

1. **Dead CSS removed**:  pageClass rule in style.css (set  which the body already has globally) and  in index.md frontmatter.
2. **Stale font reference fixed**: the first specimen's  still pointed at  (the original display font, replaced by Newsreader → Spectral). Now correctly references . Also updated the footer colophon 'Set in Fraunces' → 'Set in Spectral'.
3. **Verified**: zero  references remain anywhere, zero  references remain, build passes, 8/8 tests pass, subsite guard passes.