### PR TITLE
fix: Unicode Block page — block slug lookup

### DIFF
--- a/src/islands/UnicodeBlockPage.vue
+++ b/src/islands/UnicodeBlockPage.vue
@@ -33,7 +33,7 @@ async function loadData() {
   const allBlocks = await loadAllBlocks()
   const found = allBlocks.find(b => {
     const slug = b.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-    return slug === blockSlugParam.value
+    return slug === blockSlugParam
   })
   if (found) {
     block.value = found


### PR DESCRIPTION
blockSlugParam.value → blockSlugParam. The prop is a string, not a ref.