### PR TITLE
feat: MDX content collections + SSG @font-face injection

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,25 +1,10 @@
 import { defineConfig } from 'astro/config'
 import vue from '@astrojs/vue'
+import mdx from '@astrojs/mdx'
 import tailwindcss from '@tailwindcss/vite'
 
-// Astro migration target config.
-//
-// Kept side-by-side with vite.config.ts (vite-ssg) until the migration
-// in TODO.astro/ completes. CI/dev can use either; the eventual goal is
-// to retire vite.config.ts + vite-ssg.
-//
-// Key choices:
-//   - output: 'static' — emits pre-rendered HTML for every route
-//     (replaces vite-ssg's ssgOptions.includedRoutes)
-//   - build.format: 'directory' — emits /foo/index.html so both /foo
-//     and /foo/ resolve on GitHub Pages (matches vite-ssg dirStyle:
-//     'nested')
-//   - Vue integration — lets us mount existing .vue components as
-//     islands via client:load / client:visible / client:idle
-//   - Tailwind 4 — Vite plugin, picks up src/styles/main.css with the
-//     @theme block as-is
 export default defineConfig({
-  integrations: [vue()],
+  integrations: [vue(), mdx()],
   vite: {
     plugins: [tailwindcss()],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "vue": "^3.5.0"
       },
       "devDependencies": {
+        "@astrojs/mdx": "^4.3.14",
         "@astrojs/vue": "^5.1.4",
         "@types/node": "^25.4.0",
         "@vitejs/plugin-vue": "^6.0.7",
@@ -21,6 +22,7 @@
         "node-html-parser": "^7.0.1",
         "prettier": "^3.8.1",
         "typescript": "^5.9.3",
+        "vite": "^8.1.4",
         "vitest": "^4.1.10"
       }
     },
@@ -99,6 +101,34 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@astrojs/mdx": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-4.3.14.tgz",
+      "integrity": "sha512-FBrqJQORVm+rkRa2TS5CjU9PBA6hkhrwLVBSS9A77gN2+iehvjq1w6yya/d0YKC7osiVorKkr3Qd9wNbl0ZkGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/markdown-remark": "6.3.11",
+        "@mdx-js/mdx": "^3.1.1",
+        "acorn": "^8.15.0",
+        "es-module-lexer": "^1.7.0",
+        "estree-util-visit": "^2.0.0",
+        "hast-util-to-html": "^9.0.5",
+        "piccolore": "^0.1.3",
+        "rehype-raw": "^7.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-smartypants": "^3.0.2",
+        "source-map": "^0.7.6",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.3"
+      },
+      "engines": {
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "astro": "^5.0.0"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -2265,6 +2295,54 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mdx-js/mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
+      "integrity": "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdx": "^2.0.0",
+        "acorn": "^8.0.0",
+        "collapse-white-space": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-util-scope": "^1.0.0",
+        "estree-walker": "^3.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "markdown-extensions": "^2.0.0",
+        "recma-build-jsx": "^1.0.0",
+        "recma-jsx": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "rehype-recma": "^1.0.0",
+        "remark-mdx": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "source-map": "^0.7.0",
+        "unified": "^11.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@mdx-js/mdx/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -2630,6 +2708,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2643,6 +2722,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2656,6 +2736,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2669,6 +2750,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2682,6 +2764,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2695,6 +2778,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2708,6 +2792,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2721,6 +2806,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2734,6 +2820,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2747,6 +2834,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2760,6 +2848,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2773,6 +2862,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2786,6 +2876,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2799,6 +2890,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2812,6 +2904,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2825,6 +2918,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2838,6 +2932,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2851,6 +2946,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2864,6 +2960,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2877,6 +2974,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2890,6 +2988,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2903,6 +3002,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2916,6 +3016,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2929,6 +3030,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2942,6 +3044,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3348,7 +3451,18 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/hast": {
       "version": "3.0.5",
@@ -3369,6 +3483,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/mdx": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.14.tgz",
+      "integrity": "sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -3391,7 +3512,7 @@
       "version": "25.9.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
       "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -3811,6 +3932,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -3955,6 +4086,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
       }
     },
     "node_modules/astro": {
@@ -4911,6 +5052,17 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -4964,6 +5116,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/collapse-white-space": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/color-convert": {
@@ -5529,6 +5692,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/esast-util-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
+      "integrity": "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esast-util-from-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
+      "integrity": "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "acorn": "^8.0.0",
+        "esast-util-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
@@ -5592,6 +5789,104 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-attach-comments": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
+      "integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-build-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
+      "integrity": "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-walker": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-build-jsx/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-scope": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
+      "integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-to-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
+      "integrity": "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "astring": "^1.8.0",
+        "source-map": "^0.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/estree-walker": {
@@ -5754,6 +6049,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5970,6 +6266,35 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-estree": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
+      "integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-attach-comments": "^3.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
@@ -5988,6 +6313,34 @@
         "space-separated-tokens": "^2.0.0",
         "stringify-entities": "^4.0.0",
         "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6133,6 +6486,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
@@ -6141,6 +6501,43 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/brc-dd"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-docker": {
@@ -6167,6 +6564,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-inside-container": {
@@ -6694,6 +7102,19 @@
         "source-map-js": "^1.2.1"
       }
     },
+    "node_modules/markdown-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
+      "integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
@@ -6872,6 +7293,87 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
@@ -7161,6 +7663,113 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/micromark-extension-mdx-expression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-jsx": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-md": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark-extension-mdx-expression": "^3.0.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs-esm": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs-esm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/micromark-factory-destination": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
@@ -7204,6 +7813,34 @@
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-mdx-expression": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
       }
     },
     "node_modules/micromark-factory-space": {
@@ -7416,6 +8053,32 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/micromark-util-events-to-acorn": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
     },
     "node_modules/micromark-util-html-tag-name": {
       "version": "2.0.1",
@@ -7880,6 +8543,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/parse-latin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
@@ -8135,6 +8825,77 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/recma-build-jsx": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
+      "integrity": "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-build-jsx": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-jsx": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/recma-jsx/-/recma-jsx-1.0.1.tgz",
+      "integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn-jsx": "^5.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "recma-parse": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/recma-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz",
+      "integrity": "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "esast-util-from-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz",
+      "integrity": "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
@@ -8211,6 +8972,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-recma": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
+      "integrity": "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-stringify": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
@@ -8240,6 +9017,21 @@
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
         "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
+      "integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-mdx": "^3.0.0",
+        "micromark-extension-mdxjs": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8423,6 +9215,7 @@
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.9"
@@ -8651,6 +9444,16 @@
         "url": "https://github.com/sponsors/cyyynthia"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -8825,6 +9628,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/superjson": {
@@ -9024,7 +9847,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -9059,7 +9882,7 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -9155,6 +9978,20 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9433,21 +10270,23 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.21",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -9456,23 +10295,33 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.4.0"
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
         "@types/node": {
           "optional": true
         },
-        "less": {
+        "@vitejs/devtools": {
           "optional": true
         },
-        "lightningcss": {
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
           "optional": true
         },
         "sass": {
@@ -9488,6 +10337,12 @@
           "optional": true
         },
         "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
           "optional": true
         }
       }
@@ -9578,436 +10433,6 @@
       },
       "peerDependencies": {
         "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/vitefu": {
@@ -10162,84 +10587,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/vitest/node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
-        "tinyglobby": "^0.2.17"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.3.0",
-        "esbuild": "^0.27.0 || ^0.28.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
       }
     },
     "node_modules/vue": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "vue": "^3.5.0"
   },
   "devDependencies": {
+    "@astrojs/mdx": "^4.3.14",
     "@astrojs/vue": "^5.1.4",
     "@types/node": "^25.4.0",
     "@vitejs/plugin-vue": "^6.0.7",
@@ -37,6 +38,7 @@
     "node-html-parser": "^7.0.1",
     "prettier": "^3.8.1",
     "typescript": "^5.9.3",
+    "vite": "^8.1.4",
     "vitest": "^4.1.10"
   }
 }

--- a/src/content/blog/2022-02-11-introducing-fontist.mdx
+++ b/src/content/blog/2022-02-11-introducing-fontist.mdx
@@ -1,0 +1,202 @@
+---
+title: "Introducing Fontist: the extensible font manager"
+description: Fontist is a simple, functional and extensible font installer that works cross-platform.
+authors:
+  - Ronald Tse
+  - Alexey Morozov
+date: 2022-02-11
+---
+
+# Introducing Fontist: the extensible font manager
+
+
+
+## Purpose
+
+Fontist is a simple, functional and extensible font installer.
+
+Fontist:
+
+* *works cross-platform*: supports Windows, Linux and macOS;
+* *has extensive font support*: from first-party system-provided fonts to third-party fonts;
+* *supports automation*: works with modern continuous integration (CI) and continuous delivery (CD) systems, as well as GitHub and GitLab;
+* *facilitates font management*: supports font repositories and font manifests;
+* is *easily extensible*: easily support font packages hosted online;
+* *works natively with OS font management* software: from `font-config` to macOS' Font Book
+
+To truly grasp the intricacies of font management, some specific terms are used
+in this article.
+
+
+## Terms and definitions
+
+The following terms are used in the article.
+
+<dl>
+
+  <dt><strong>font</strong></dt>
+  <dd>group of glyphs of the same design style, with each glyph referenced by a unique character code</dd>
+
+  <dt><strong>glyph</strong></dt>
+  <dd>vector graphic representing a literary character, such as a character in an alphabet or a pictogram</dd>
+
+  <dt><strong>font family (or type family)</strong></dt>
+  <dd>group of fonts sharing a design style</dd>
+
+  <dt><strong>font style</strong></dt>
+  <dd>style of the font within a font family, typically of the variants "regular", "bold" and "italic"</dd>
+
+  <dt><strong>font weight</strong></dt>
+  <dd>heaviness of the font in comparison with other fonts in the same font family, typically a higher number represents a bolder font</dd>
+
+  <dt><strong>font formula</strong></dt>
+  <dd>Fontist object (in YAML) containing description and instructions on fonts contained in an external distributed package that contains fonts</dd>
+
+  <dt><strong>font manifest</strong></dt>
+  <dd>Fontist object (in YAML) containing a coherent listing of font families and font styles indicating fonts to be installed together, typically for a particular purpose</dd>
+
+  <dt><strong>font formula repository (or: Fontist repo)</strong></dt>
+  <dd>Git repository used by Fontist to contain Fontist font formulas</dd>
+
+</dl>
+
+
+## Installing Fontist
+
+Fontist works across all major platforms, including Windows, Linux and macOS.
+
+The core of the Fontist software is in Ruby and utilizes C for its multitude of
+archival handling methods.
+
+Ruby can be installed on all major platforms following
+[the official guide](https://www.ruby-lang.org/en/documentation/installation/).
+
+When Ruby is set up, `fontist` can be installed as a gem (or as a Ruby library).
+
+After installing, the `fontist` command becomes available:
+
+```sh
+$ gem install fontist
+$ fontist help
+Commands:
+  fontist cache SUBCOMMAND ...ARGS       # Manage fontist cache
+  fontist config SUBCOMMAND ...ARGS      # Manage fontist config
+  fontist create-formula URL             # Create a new formula with fonts from URL
+  fontist fontconfig SUBCOMMAND ...ARGS  # Manage fontconfig
+  fontist help [COMMAND]                 # Describe available commands or one specific command
+  fontist import SUBCOMMAND ...ARGS      # Manage imports
+  fontist install FONT                   # Install font
+  fontist list [FONT]                    # List installation status of FONT or fonts in fontist
+  fontist manifest-install MANIFEST      # Install fonts from MANIFEST (yaml)
+  fontist manifest-locations MANIFEST    # Get locations of fonts from MANIFEST (yaml)
+  fontist rebuild-index                  # Rebuild formula index (used by formulas maintainers)
+  fontist repo SUBCOMMAND ...ARGS        # Manage custom repositories
+  fontist status [FONT]                  # Show paths of FONT or all fonts
+  fontist uninstall/remove FONT          # Uninstall font by font or formula
+  fontist update                         # Update formulas
+
+Options:
+     [--preferred-family], [--no-preferred-family]  # Use Preferred Family when available
+  q, [--quiet], [--no-quiet]                        # Hide all messages
+  v, [--verbose], [--no-verbose]                    # Print debug messages
+  c, [--no-cache], [--no-no-cache]                  # Avoid using cache during download
+     [--formulas-path=FORMULAS_PATH]                # Path to formulas
+```
+
+
+## Listing out supported fonts
+
+Fontist allows installing fonts from the
+[Fontist formulas repository](https://github.com/fontist/formulas)
+managed on GitHub.
+
+Each Fontist font formula typically represents a coherent collection of fonts,
+a single package containing one or more fonts distributed together.
+
+These fonts may be of the same font family or of disparate families.
+
+Fontist font formulas currently support fonts from:
+
+* [Google Fonts](https://fonts.google.com)
+* [SIL International](https://software.sil.org/fonts/)
+* open-source language-specific fonts such as: [IPAex (Japanese)](https://moji.or.jp/ipafont/ipaex00401/) and [Euphemia (Canadian Syllabics)](https://www.tiro.com/fonts/euphemia)
+* math and science fonts such as: [STIX](https://www.stixfonts.org)
+* TeX fonts such as: [TeX Gyre](https://www.gust.org.pl/projects/e-foundry/tex-gyre/)
+* curated and contributed fonts
+
+To check what fonts are installed on your system:
+```sh
+$ fontist status
+```
+
+To see what fonts that can be installed:
+```sh
+$ fontist list
+```
+
+Number of font formulas: *2,175* (as of 2026-03-07)
+Number of font styles: *14,500+* (as of 2026-03-07)
+
+
+## Font format support
+
+Fontist supports major font formats including:
+
+* TrueType (`*.ttf`) and TrueType Collections (`*.ttc`)
+* OpenType and OpenType Collections (`*.otf` for both)
+* Web Open Font Format 1 and 2 (`*.woff` and `*.woff2`)
+
+Fontist does not yet support Adobe PostScript fonts such as `*.pf{a,b,m}`.
+
+
+## Installing a font
+
+It is easy to install a font using Fontist via the CLI:
+
+```sh
+$ fontist install Arial
+```
+
+That's it!
+
+
+## Command-line interface and Ruby API
+
+Fontist provides both a command-line interface, the `fontist` executable,
+and a programmatic interface in Ruby.
+
+For example, the following code will allow the program to know what
+fonts are supplied by the current system given a font manifest:
+
+```ruby
+> manifest = {
+  "Segoe UI"=>["Regular", "Bold"],
+  "Roboto Mono"=>["Regular"]
+}
+> Fontist::Manifest::Locations.from_hash(manifest)
+=>
+  {
+    "Segoe UI"=> {
+      "Regular"=>{
+        "full_name"=>"Segoe UI",
+        "paths"=>["/Users/user/.fontist/fonts/SEGOEUI.TTF"]
+      },
+      "Bold"=>{
+        "full_name"=>"Segoe UI Bold",
+        "paths"=>["/Users/user/.fontist/fonts/SEGOEUIB.TTF"]
+      }
+    },
+    "Roboto Mono"=> {
+      "Regular"=>{
+        "full_name"=>nil,
+        "paths"=>[]
+      }
+    }
+  }
+```
+
+## Additional information
+
+There are many Fontist features that facilitate the installation and management
+of fonts across platforms. Stay tuned with our blog and check out the home page
+for further details!

--- a/src/content/blog/2022-02-11-introducing-fontist.mdx.bak
+++ b/src/content/blog/2022-02-11-introducing-fontist.mdx.bak
@@ -1,0 +1,202 @@
+---
+title: "Introducing Fontist: the extensible font manager"
+description: Fontist is a simple, functional and extensible font installer that works cross-platform.
+authors:
+  - Ronald Tse
+  - Alexey Morozov
+date: 2022-02-11
+---
+
+# Introducing Fontist: the extensible font manager
+
+<BlogByline />
+
+## Purpose
+
+Fontist is a simple, functional and extensible font installer.
+
+Fontist:
+
+* *works cross-platform*: supports Windows, Linux and macOS;
+* *has extensive font support*: from first-party system-provided fonts to third-party fonts;
+* *supports automation*: works with modern continuous integration (CI) and continuous delivery (CD) systems, as well as GitHub and GitLab;
+* *facilitates font management*: supports font repositories and font manifests;
+* is *easily extensible*: easily support font packages hosted online;
+* *works natively with OS font management* software: from `font-config` to macOS' Font Book
+
+To truly grasp the intricacies of font management, some specific terms are used
+in this article.
+
+
+## Terms and definitions
+
+The following terms are used in the article.
+
+<dl>
+
+  <dt><strong>font</strong></dt>
+  <dd>group of glyphs of the same design style, with each glyph referenced by a unique character code</dd>
+
+  <dt><strong>glyph</strong></dt>
+  <dd>vector graphic representing a literary character, such as a character in an alphabet or a pictogram</dd>
+
+  <dt><strong>font family (or type family)</strong></dt>
+  <dd>group of fonts sharing a design style</dd>
+
+  <dt><strong>font style</strong></dt>
+  <dd>style of the font within a font family, typically of the variants "regular", "bold" and "italic"</dd>
+
+  <dt><strong>font weight</strong></dt>
+  <dd>heaviness of the font in comparison with other fonts in the same font family, typically a higher number represents a bolder font</dd>
+
+  <dt><strong>font formula</strong></dt>
+  <dd>Fontist object (in YAML) containing description and instructions on fonts contained in an external distributed package that contains fonts</dd>
+
+  <dt><strong>font manifest</strong></dt>
+  <dd>Fontist object (in YAML) containing a coherent listing of font families and font styles indicating fonts to be installed together, typically for a particular purpose</dd>
+
+  <dt><strong>font formula repository (or: Fontist repo)</strong></dt>
+  <dd>Git repository used by Fontist to contain Fontist font formulas</dd>
+
+</dl>
+
+
+## Installing Fontist
+
+Fontist works across all major platforms, including Windows, Linux and macOS.
+
+The core of the Fontist software is in Ruby and utilizes C for its multitude of
+archival handling methods.
+
+Ruby can be installed on all major platforms following
+[the official guide](https://www.ruby-lang.org/en/documentation/installation/).
+
+When Ruby is set up, `fontist` can be installed as a gem (or as a Ruby library).
+
+After installing, the `fontist` command becomes available:
+
+```sh
+$ gem install fontist
+$ fontist help
+Commands:
+  fontist cache SUBCOMMAND ...ARGS       # Manage fontist cache
+  fontist config SUBCOMMAND ...ARGS      # Manage fontist config
+  fontist create-formula URL             # Create a new formula with fonts from URL
+  fontist fontconfig SUBCOMMAND ...ARGS  # Manage fontconfig
+  fontist help [COMMAND]                 # Describe available commands or one specific command
+  fontist import SUBCOMMAND ...ARGS      # Manage imports
+  fontist install FONT                   # Install font
+  fontist list [FONT]                    # List installation status of FONT or fonts in fontist
+  fontist manifest-install MANIFEST      # Install fonts from MANIFEST (yaml)
+  fontist manifest-locations MANIFEST    # Get locations of fonts from MANIFEST (yaml)
+  fontist rebuild-index                  # Rebuild formula index (used by formulas maintainers)
+  fontist repo SUBCOMMAND ...ARGS        # Manage custom repositories
+  fontist status [FONT]                  # Show paths of FONT or all fonts
+  fontist uninstall/remove FONT          # Uninstall font by font or formula
+  fontist update                         # Update formulas
+
+Options:
+     [--preferred-family], [--no-preferred-family]  # Use Preferred Family when available
+  q, [--quiet], [--no-quiet]                        # Hide all messages
+  v, [--verbose], [--no-verbose]                    # Print debug messages
+  c, [--no-cache], [--no-no-cache]                  # Avoid using cache during download
+     [--formulas-path=FORMULAS_PATH]                # Path to formulas
+```
+
+
+## Listing out supported fonts
+
+Fontist allows installing fonts from the
+[Fontist formulas repository](https://github.com/fontist/formulas)
+managed on GitHub.
+
+Each Fontist font formula typically represents a coherent collection of fonts,
+a single package containing one or more fonts distributed together.
+
+These fonts may be of the same font family or of disparate families.
+
+Fontist font formulas currently support fonts from:
+
+* [Google Fonts](https://fonts.google.com)
+* [SIL International](https://software.sil.org/fonts/)
+* open-source language-specific fonts such as: [IPAex (Japanese)](https://moji.or.jp/ipafont/ipaex00401/) and [Euphemia (Canadian Syllabics)](https://www.tiro.com/fonts/euphemia)
+* math and science fonts such as: [STIX](https://www.stixfonts.org)
+* TeX fonts such as: [TeX Gyre](https://www.gust.org.pl/projects/e-foundry/tex-gyre/)
+* curated and contributed fonts
+
+To check what fonts are installed on your system:
+```sh
+$ fontist status
+```
+
+To see what fonts that can be installed:
+```sh
+$ fontist list
+```
+
+Number of font formulas: *2,175* (as of 2026-03-07)
+Number of font styles: *14,500+* (as of 2026-03-07)
+
+
+## Font format support
+
+Fontist supports major font formats including:
+
+* TrueType (`*.ttf`) and TrueType Collections (`*.ttc`)
+* OpenType and OpenType Collections (`*.otf` for both)
+* Web Open Font Format 1 and 2 (`*.woff` and `*.woff2`)
+
+Fontist does not yet support Adobe PostScript fonts such as `*.pf{a,b,m}`.
+
+
+## Installing a font
+
+It is easy to install a font using Fontist via the CLI:
+
+```sh
+$ fontist install Arial
+```
+
+That's it!
+
+
+## Command-line interface and Ruby API
+
+Fontist provides both a command-line interface, the `fontist` executable,
+and a programmatic interface in Ruby.
+
+For example, the following code will allow the program to know what
+fonts are supplied by the current system given a font manifest:
+
+```ruby
+> manifest = {
+  "Segoe UI"=>["Regular", "Bold"],
+  "Roboto Mono"=>["Regular"]
+}
+> Fontist::Manifest::Locations.from_hash(manifest)
+=>
+  {
+    "Segoe UI"=> {
+      "Regular"=>{
+        "full_name"=>"Segoe UI",
+        "paths"=>["/Users/user/.fontist/fonts/SEGOEUI.TTF"]
+      },
+      "Bold"=>{
+        "full_name"=>"Segoe UI Bold",
+        "paths"=>["/Users/user/.fontist/fonts/SEGOEUIB.TTF"]
+      }
+    },
+    "Roboto Mono"=> {
+      "Regular"=>{
+        "full_name"=>nil,
+        "paths"=>[]
+      }
+    }
+  }
+```
+
+## Additional information
+
+There are many Fontist features that facilitate the installation and management
+of fonts across platforms. Stay tuned with our blog and check out the home page
+for further details!

--- a/src/content/blog/2022-02-11-macos-fonts.mdx
+++ b/src/content/blog/2022-02-11-macos-fonts.mdx
@@ -1,0 +1,180 @@
+---
+title: Installing macOS-specific add-on fonts
+description: Learn how to install macOS-specific add-on fonts via the fontist command-line interface.
+authors:
+  - Ronald Tse
+  - Alexey Morozov
+date: 2022-02-11
+---
+
+# Installing macOS-specific add-on fonts
+
+
+
+Fontist now allows installing macOS-specific add-on fonts via the `fontist`
+command-line interface.
+
+## Introduction
+
+macOS comes with an amazingly beautiful set of fonts. These fonts typically
+require commercial licenses to be used on other platforms, so macOS makes good
+on the Apple reputation that design comes essential and affordable.
+
+Designers using Apple products often rely on Apple supplied typefaces,
+some of the commonly used fonts include:
+
+* Avenir Next
+* Canela
+* Futura
+* Georgia
+* Palatino
+
+
+
+## Available fonts on macOS systems
+
+Since macOS 11 (Big Sur), the font list provided by macOS grew sufficiently
+large that many fonts are now downloaded upon demand.
+macOS fonts are now distributed in one of these two ways:
+
+* supplied by the default installation
+* downloadable on demand
+
+In fact, macOS
+[Font Book supports removal of the supplied fonts](https://support.apple.com/en-hk/guide/font-book/fntbk1000/mac)
+to be installed on demand after a font is manually removed, so all fonts are
+technically available to the system at any time.
+
+The full list of available fonts on various macOS versions can be found on the
+Apple Support site:
+
+* [Fonts in macOS 14 Sonoma](https://support.apple.com/en-us/108939)
+* [Fonts in macOS 13 Ventura](https://support.apple.com/en-us/HT213266)
+* [Fonts in macOS 12 Monteray](https://support.apple.com/en-us/HT212587)
+* [Fonts in macOS 11 Big Sur](https://support.apple.com/en-in/HT211240)
+
+
+## Installing macOS fonts
+
+Fontist makes it possible for the user to bypass the macOS Font Book UI and
+installing these specially licensed fonts in a continuous integration (CI)
+manner on macOS environments.
+
+Here's how to install macOS fonts through Fontist.
+
+First update the collection of Fontist font formulas using the
+`fontist update` command:
+
+```sh
+$ fontist update
+Formulas have been successfully updated.
+```
+
+Now individual fonts can be installed by referring to their font names:
+
+```sh
+$ fontist install "Canela"
+...
+Font "Canela" not found locally.
+FONT LICENSE ACCEPTANCE REQUIRED FOR "Canela":
+
+Fontist can install this font if you accept its licensing conditions.
+
+FONT LICENSE BEGIN ("Canela")
+-----------------------------------------------------------------------
+For use on Apple-branded Systems
+...
+-----------------------------------------------------------------------
+FONT LICENSE END ("Canela")
+
+Do you accept all presented font licenses, and want Fontist to download these fonts for you?
+=> TYPE 'Yes' or 'No': Yes
+...
+Installing font "macos/canela".
+Fonts installed at:
+- /Users/john/.fontist/fonts/Canela.ttc
+```
+
+
+## Using macOS fonts in continuous integration
+
+In a continuous integration (CI) system it is important that the installs
+do not require user interaction.
+
+The Fontist CLI provides flags for the system to answer mandatory prompts
+at time of execution:
+
+* The `--accept-all-licenses` flag allows the `install` command to install a
+font, while providing explicit acceptance through a command-line option.
+
+The `--force` flag ensures that `fontist` installs the font even if it's already
+present in the system, thereby guaranteeing its presence in the target path.
+
+```sh
+$ fontist install --accept-all-licenses --force "Canela"
+```
+
+
+## Example using a macOS font in a generated design
+
+The following demonstration shows how useful this is in a CI environment.
+
+The "Canela" font is a commonly-used commercial font that comes free with
+macOS, and the "_The Blood Is At The Doorstep_" movie poster uses the Canela font.
+
+This is the original poster:
+
+![Original poster](https://i.imgur.com/ZsNgRCZ.png)
+_Source: mdfilmfest.com License: All Rights Reserved._
+[Link to poster](https://fontsinuse.com/uses/18269/the-blood-is-at-the-doorstep-movie-poster)
+
+And we will generate the same using a CI.
+
+
+### Prerequisites
+
+Install the Canela font on macOS using
+[Fontist](https://github.com/fontist/fontist):
+
+```sh
+$ fontist install Canela
+```
+
+### Generating an image
+
+We can generate the title using ImageMagick in a CI environment.
+
+As described on the
+[ImageMagic `convert` page](https://imagemagick.org/script/convert.php), we can
+use the `magick convert` command to generate this exact same title.
+
+The command to generate the title:
+
+```sh
+$ magick convert \
+   -size 800x1066 canvas:black \
+   -font Canela-Regular-Regular \
+   -pointsize 180 \
+   -fill white \
+   -kerning 0  -interword-spacing 180 -annotate +25+170 'T H E' \
+   -kerning 22 -annotate +35+340 'BLOOD' \
+   -kerning 60 -interword-spacing 75  -annotate +60+510 'IS AT' \
+   -kerning 0  -interword-spacing 180 -annotate +25+680 'T H E' \
+   -kerning 60 -annotate +35+850 'DOOR' \
+   -kerning 95 -annotate +35+1020 'STEP' \
+   poster.png
+```
+
+The generated version is pretty much identical (except for the background)!
+
+![Generated poster](https://i.imgur.com/waGfDP8.png)
+
+
+## Conclusion
+
+Fontist provides you with a convenient way to install fonts outside of
+system limitations, allowing CI systems to utilize macOS licensed fonts
+without user interaction.
+
+As always, if you need help with the new functionality, please post at
+the [Fontist Issues page](https://github.com/fontist/fontist/issues)!

--- a/src/content/blog/2022-02-11-macos-fonts.mdx.bak
+++ b/src/content/blog/2022-02-11-macos-fonts.mdx.bak
@@ -1,0 +1,180 @@
+---
+title: Installing macOS-specific add-on fonts
+description: Learn how to install macOS-specific add-on fonts via the fontist command-line interface.
+authors:
+  - Ronald Tse
+  - Alexey Morozov
+date: 2022-02-11
+---
+
+# Installing macOS-specific add-on fonts
+
+<BlogByline />
+
+Fontist now allows installing macOS-specific add-on fonts via the `fontist`
+command-line interface.
+
+## Introduction
+
+macOS comes with an amazingly beautiful set of fonts. These fonts typically
+require commercial licenses to be used on other platforms, so macOS makes good
+on the Apple reputation that design comes essential and affordable.
+
+Designers using Apple products often rely on Apple supplied typefaces,
+some of the commonly used fonts include:
+
+* Avenir Next
+* Canela
+* Futura
+* Georgia
+* Palatino
+
+
+
+## Available fonts on macOS systems
+
+Since macOS 11 (Big Sur), the font list provided by macOS grew sufficiently
+large that many fonts are now downloaded upon demand.
+macOS fonts are now distributed in one of these two ways:
+
+* supplied by the default installation
+* downloadable on demand
+
+In fact, macOS
+[Font Book supports removal of the supplied fonts](https://support.apple.com/en-hk/guide/font-book/fntbk1000/mac)
+to be installed on demand after a font is manually removed, so all fonts are
+technically available to the system at any time.
+
+The full list of available fonts on various macOS versions can be found on the
+Apple Support site:
+
+* [Fonts in macOS 14 Sonoma](https://support.apple.com/en-us/108939)
+* [Fonts in macOS 13 Ventura](https://support.apple.com/en-us/HT213266)
+* [Fonts in macOS 12 Monteray](https://support.apple.com/en-us/HT212587)
+* [Fonts in macOS 11 Big Sur](https://support.apple.com/en-in/HT211240)
+
+
+## Installing macOS fonts
+
+Fontist makes it possible for the user to bypass the macOS Font Book UI and
+installing these specially licensed fonts in a continuous integration (CI)
+manner on macOS environments.
+
+Here's how to install macOS fonts through Fontist.
+
+First update the collection of Fontist font formulas using the
+`fontist update` command:
+
+```sh
+$ fontist update
+Formulas have been successfully updated.
+```
+
+Now individual fonts can be installed by referring to their font names:
+
+```sh
+$ fontist install "Canela"
+...
+Font "Canela" not found locally.
+FONT LICENSE ACCEPTANCE REQUIRED FOR "Canela":
+
+Fontist can install this font if you accept its licensing conditions.
+
+FONT LICENSE BEGIN ("Canela")
+-----------------------------------------------------------------------
+For use on Apple-branded Systems
+...
+-----------------------------------------------------------------------
+FONT LICENSE END ("Canela")
+
+Do you accept all presented font licenses, and want Fontist to download these fonts for you?
+=> TYPE 'Yes' or 'No': Yes
+...
+Installing font "macos/canela".
+Fonts installed at:
+- /Users/john/.fontist/fonts/Canela.ttc
+```
+
+
+## Using macOS fonts in continuous integration
+
+In a continuous integration (CI) system it is important that the installs
+do not require user interaction.
+
+The Fontist CLI provides flags for the system to answer mandatory prompts
+at time of execution:
+
+* The `--accept-all-licenses` flag allows the `install` command to install a
+font, while providing explicit acceptance through a command-line option.
+
+The `--force` flag ensures that `fontist` installs the font even if it's already
+present in the system, thereby guaranteeing its presence in the target path.
+
+```sh
+$ fontist install --accept-all-licenses --force "Canela"
+```
+
+
+## Example using a macOS font in a generated design
+
+The following demonstration shows how useful this is in a CI environment.
+
+The "Canela" font is a commonly-used commercial font that comes free with
+macOS, and the "_The Blood Is At The Doorstep_" movie poster uses the Canela font.
+
+This is the original poster:
+
+![Original poster](https://i.imgur.com/ZsNgRCZ.png)
+_Source: mdfilmfest.com License: All Rights Reserved._
+[Link to poster](https://fontsinuse.com/uses/18269/the-blood-is-at-the-doorstep-movie-poster)
+
+And we will generate the same using a CI.
+
+
+### Prerequisites
+
+Install the Canela font on macOS using
+[Fontist](https://github.com/fontist/fontist):
+
+```sh
+$ fontist install Canela
+```
+
+### Generating an image
+
+We can generate the title using ImageMagick in a CI environment.
+
+As described on the
+[ImageMagic `convert` page](https://imagemagick.org/script/convert.php), we can
+use the `magick convert` command to generate this exact same title.
+
+The command to generate the title:
+
+```sh
+$ magick convert \
+   -size 800x1066 canvas:black \
+   -font Canela-Regular-Regular \
+   -pointsize 180 \
+   -fill white \
+   -kerning 0  -interword-spacing 180 -annotate +25+170 'T H E' \
+   -kerning 22 -annotate +35+340 'BLOOD' \
+   -kerning 60 -interword-spacing 75  -annotate +60+510 'IS AT' \
+   -kerning 0  -interword-spacing 180 -annotate +25+680 'T H E' \
+   -kerning 60 -annotate +35+850 'DOOR' \
+   -kerning 95 -annotate +35+1020 'STEP' \
+   poster.png
+```
+
+The generated version is pretty much identical (except for the background)!
+
+![Generated poster](https://i.imgur.com/waGfDP8.png)
+
+
+## Conclusion
+
+Fontist provides you with a convenient way to install fonts outside of
+system limitations, allowing CI systems to utilize macOS licensed fonts
+without user interaction.
+
+As always, if you need help with the new functionality, please post at
+the [Fontist Issues page](https://github.com/fontist/fontist/issues)!

--- a/src/content/blog/2024-01-23-office-fonts.mdx
+++ b/src/content/blog/2024-01-23-office-fonts.mdx
@@ -1,0 +1,292 @@
+---
+title: Installing Microsoft Office fonts
+description: Fontist now supports installing fonts from Microsoft Office packages.
+authors:
+  - Ronald Tse
+  - Alexey Morozov
+date: 2024-01-23
+---
+
+# Installing Microsoft Office fonts
+
+
+
+Fontist now supports installing fonts from Microsoft Office packages.
+
+## Introduction
+
+Microsoft Office is still the premier office suite today, like it or not. One
+reason is that it comes with a set of widely-used, well curated and high quality
+fonts, including:
+
+* for Latin, the Word default fonts like
+[Cambria](https://en.wikipedia.org/wiki/Cambria_(typeface)) and
+[Calibri](https://en.wikipedia.org/wiki/Calibri);
+
+* for CJK, full glyph fonts like
+[MS Mincho](https://learn.microsoft.com/en-us/typography/font-list/ms-mincho),
+[MS PGothic](https://learn.microsoft.com/en-us/typography/font-list/ms-pgothic),
+[MingLiU](https://learn.microsoft.com/en-us/typography/font-list/mingliu),
+[SimHei](https://learn.microsoft.com/en-us/typography/font-list/simhei),
+[SimSun](https://learn.microsoft.com/en-us/typography/font-list/simsun).
+
+Fontist users have long requested fonts that are only available from Microsoft
+Office, such as "MS PGothic"
+([issue #70](https://github.com/fontist/formulas/issues/70#issuecomment-752422687) from 2020!).
+"MS PGothic" is a font for the Japanese language that is commonly used,
+including for documents issued by the Japanese government.
+
+Wait... aren't there already freely-licensed, compatible fonts with
+"MS PGothic"?
+
+"HGPGothicM" is one of such, that is not only freely available, but it was also
+produced by Ricoh, the same company that produced "MS PGothic".
+
+While "HGPGothicM" is nearly identical, it is not:
+
+* metric-compatible, which would cause layout flow issues;
+* registered under the "MS PGothic" name, which would cause problems to software
+  that open files using the font, such as LibreOffice and WPS Office.
+
+NOTE: Differences between "MS PGothic" and "HGPGothicM" is found on
+[Ricoh's page](https://industry.ricoh.com/en/font/true_type_font/).
+
+
+## Available Office fonts
+
+"Preview" versions of Microsoft Office software can be installed on Windows and
+macOS machines for demonstrational purposes, and when installed, its fonts
+become available on the computer.
+
+Fontist has now implemented support for XAR decompression which allows usage of
+fonts from within the "Office Preview" packages.
+
+The ["Office Preview"](https://github.com/fontist/formulas/blob/v3/Formulas/office_preview.yml)
+formula includes 91 new fonts, including "MS PGothic" and many others with
+updated versions, totalling 149 fonts.
+
+Here is the full list of fonts from the Office package.
+
+<details>
+<summary>Click to expand list</summary>
+
+### Font listing of the Office preview package
+
+* Abadi MT Condensed Extra Bold
+* Abadi MT Condensed Light
+* Arial
+* Arial Black
+* Arial Narrow
+* Arial Rounded MT Bold
+* Baskerville Old Face
+* Batang
+* BatangChe
+* Bauhaus 93
+* Bell MT
+* Bernard MT Condensed
+* Book Antiqua
+* Bookman Old Style
+* Bookshelf Symbol 7
+* Braggadocio
+* Britannic Bold
+* Calibri
+* Calibri Light
+* Calisto MT
+* Cambria
+* Cambria Math
+* Candara
+* Century
+* Century Gothic
+* Century Schoolbook
+* Colonna MT
+* Comic Sans MS
+* Consolas
+* Constantia
+* Copperplate Gothic Bold
+* Corbel
+* Curlz MT
+* DengXian
+* DengXian Light
+* Desdemona
+* Dotum
+* DotumChe
+* Edwardian Script ITC
+* Engravers MT
+* Eurostile
+* FangSong
+* Footlight MT Light
+* Franklin Gothic Book
+* Franklin Gothic Demi
+* Franklin Gothic Demi Cond
+* Franklin Gothic Heavy
+* Franklin Gothic Medium
+* Franklin Gothic Medium Cond
+* Gabriola
+* Garamond
+* Gill Sans MT
+* Gill Sans MT Condensed
+* Gill Sans MT Ext Condensed Bold
+* Gill Sans Ultra Bold
+* Gloucester MT Extra Condensed
+* Goudy Old Style
+* Gulim
+* GulimChe
+* Gungsuh
+* GungsuhChe
+* HGGothicE
+* HGMaruGothicMPRO
+* HGMinchoE
+* HGPGothicE
+* HGPMinchoE
+* HGPSoeiKakugothicUB
+* HGSGothicE
+* HGSMinchoE
+* HGSSoeiKakugothicUB
+* HGSoeiKakugothicUB
+* Haettenschweiler
+* Harrington
+* Imprint MT Shadow
+* KaiTi
+* Kino MT
+* Lucida Blackletter
+* Lucida Bright
+* Lucida Calligraphy
+* Lucida Console
+* Lucida Fax
+* Lucida Handwriting
+* Lucida Sans
+* Lucida Sans Typewriter
+* Lucida Sans Unicode
+* MS Gothic
+* MS Mincho
+* MS PGothic
+* MS PMincho
+* MS Reference Sans Serif
+* MS Reference Specialty
+* MS UI Gothic
+* MT Extra
+* Malgun Gothic
+* Malgun Gothic Semilight
+* Marlett
+* Matura MT Script Capitals
+* Meiryo
+* Microsoft Himalaya
+* Microsoft JhengHei
+* Microsoft New Tai Lue
+* Microsoft Tai Le
+* Microsoft YaHei
+* Microsoft Yi Baiti
+* MingLiU
+* MingLiU-ExtB
+* MingLiU_HKSCS
+* MingLiU_HKSCS-ExtB
+* Mistral
+* Modern No. 20
+* Mongolian Baiti
+* Monotype Corsiva
+* Monotype Sorts
+* News Gothic MT
+* Onyx
+* PMingLiU
+* PMingLiU-ExtB
+* Palatino Linotype
+* Perpetua
+* Perpetua Titling MT
+* Rockwell
+* Rockwell Condensed
+* Rockwell Extra Bold
+* STHupo
+* STLiti
+* STXingkai
+* STXinwei
+* STZhongsong
+* Segoe Print
+* Segoe Script
+* SimHei
+* SimSun
+* SimSun-ExtB
+* Stencil
+* Tahoma
+* Trebuchet MS
+* Tw Cen MT
+* Tw Cen MT Condensed
+* Tw Cen MT Condensed Extra Bold
+* Verdana
+* Webdings
+* Wide Latin
+* Wingdings
+* Wingdings 2
+* Wingdings 3
+* Yu Gothic
+* Yu Gothic Light
+* Yu Gothic Medium
+* Yu Mincho
+</details>
+
+
+
+## Installing Office fonts
+
+Here's how to install "MS PGothic", "MS PMincho" and other Office fonts
+through Fontist.
+
+First update the collection of Fontist font formulas using the
+`fontist update` command:
+
+```sh
+$ fontist update
+Formulas have been successfully updated.
+```
+
+Now individual fonts can be installed by referring to their font names:
+
+```sh
+$ fontist install "MS PGothic"
+Fonts installed at:
+- /Users/john/.fontist/fonts/msgothic.ttc
+```
+
+Alternatively, all fonts from the same formula can be installed using the
+formula name:
+
+```sh
+$ fontist install --formula office_preview
+Fonts installed at:
+- /Users/john/.fontist/fonts/Rockwell Extra Bold.ttf
+- /Users/john/.fontist/fonts/webdings.ttf
+- /Users/john/.fontist/fonts/Dengb.ttf
+- /Users/john/.fontist/fonts/Candarai.ttf
+- /Users/john/.fontist/fonts/Cambria.ttc
+- /Users/john/.fontist/fonts/Verdana Bold.ttf
+- /Users/john/.fontist/fonts/GillSansUltraBold.ttf
+...
+```
+
+## Using Office fonts in continuous integration
+
+`fontist` supports flags that can be utilized in continuous integration (CI)
+systems.
+
+For instance:
+
+* The `--accept-all-licenses` flag allows the `install` command to install a
+font, while providing explicit acceptance through a command-line option.
+
+The `--force` flag ensures that `fontist` installs the font even if it's already
+present in the system, thereby guaranteeing its presence in the target path.
+
+```sh
+$ fontist install --accept-all-licenses --force "MS PGothic"
+```
+
+
+## Conclusion
+
+Fontist now supports a growing number of fonts and serve as a convenient
+method to install fonts programmatically, especially on continuous integration
+systems.
+
+Small announcement. A standalone package of `fontist` is currently in
+development. Soon, there would be even no need to install Ruby separately to
+use `fontist`.
+

--- a/src/content/blog/2024-01-23-office-fonts.mdx.bak
+++ b/src/content/blog/2024-01-23-office-fonts.mdx.bak
@@ -1,0 +1,292 @@
+---
+title: Installing Microsoft Office fonts
+description: Fontist now supports installing fonts from Microsoft Office packages.
+authors:
+  - Ronald Tse
+  - Alexey Morozov
+date: 2024-01-23
+---
+
+# Installing Microsoft Office fonts
+
+<BlogByline />
+
+Fontist now supports installing fonts from Microsoft Office packages.
+
+## Introduction
+
+Microsoft Office is still the premier office suite today, like it or not. One
+reason is that it comes with a set of widely-used, well curated and high quality
+fonts, including:
+
+* for Latin, the Word default fonts like
+[Cambria](https://en.wikipedia.org/wiki/Cambria_(typeface)) and
+[Calibri](https://en.wikipedia.org/wiki/Calibri);
+
+* for CJK, full glyph fonts like
+[MS Mincho](https://learn.microsoft.com/en-us/typography/font-list/ms-mincho),
+[MS PGothic](https://learn.microsoft.com/en-us/typography/font-list/ms-pgothic),
+[MingLiU](https://learn.microsoft.com/en-us/typography/font-list/mingliu),
+[SimHei](https://learn.microsoft.com/en-us/typography/font-list/simhei),
+[SimSun](https://learn.microsoft.com/en-us/typography/font-list/simsun).
+
+Fontist users have long requested fonts that are only available from Microsoft
+Office, such as "MS PGothic"
+([issue #70](https://github.com/fontist/formulas/issues/70#issuecomment-752422687) from 2020!).
+"MS PGothic" is a font for the Japanese language that is commonly used,
+including for documents issued by the Japanese government.
+
+Wait... aren't there already freely-licensed, compatible fonts with
+"MS PGothic"?
+
+"HGPGothicM" is one of such, that is not only freely available, but it was also
+produced by Ricoh, the same company that produced "MS PGothic".
+
+While "HGPGothicM" is nearly identical, it is not:
+
+* metric-compatible, which would cause layout flow issues;
+* registered under the "MS PGothic" name, which would cause problems to software
+  that open files using the font, such as LibreOffice and WPS Office.
+
+NOTE: Differences between "MS PGothic" and "HGPGothicM" is found on
+[Ricoh's page](https://industry.ricoh.com/en/font/true_type_font/).
+
+
+## Available Office fonts
+
+"Preview" versions of Microsoft Office software can be installed on Windows and
+macOS machines for demonstrational purposes, and when installed, its fonts
+become available on the computer.
+
+Fontist has now implemented support for XAR decompression which allows usage of
+fonts from within the "Office Preview" packages.
+
+The ["Office Preview"](https://github.com/fontist/formulas/blob/v3/Formulas/office_preview.yml)
+formula includes 91 new fonts, including "MS PGothic" and many others with
+updated versions, totalling 149 fonts.
+
+Here is the full list of fonts from the Office package.
+
+<details>
+<summary>Click to expand list</summary>
+
+### Font listing of the Office preview package
+
+* Abadi MT Condensed Extra Bold
+* Abadi MT Condensed Light
+* Arial
+* Arial Black
+* Arial Narrow
+* Arial Rounded MT Bold
+* Baskerville Old Face
+* Batang
+* BatangChe
+* Bauhaus 93
+* Bell MT
+* Bernard MT Condensed
+* Book Antiqua
+* Bookman Old Style
+* Bookshelf Symbol 7
+* Braggadocio
+* Britannic Bold
+* Calibri
+* Calibri Light
+* Calisto MT
+* Cambria
+* Cambria Math
+* Candara
+* Century
+* Century Gothic
+* Century Schoolbook
+* Colonna MT
+* Comic Sans MS
+* Consolas
+* Constantia
+* Copperplate Gothic Bold
+* Corbel
+* Curlz MT
+* DengXian
+* DengXian Light
+* Desdemona
+* Dotum
+* DotumChe
+* Edwardian Script ITC
+* Engravers MT
+* Eurostile
+* FangSong
+* Footlight MT Light
+* Franklin Gothic Book
+* Franklin Gothic Demi
+* Franklin Gothic Demi Cond
+* Franklin Gothic Heavy
+* Franklin Gothic Medium
+* Franklin Gothic Medium Cond
+* Gabriola
+* Garamond
+* Gill Sans MT
+* Gill Sans MT Condensed
+* Gill Sans MT Ext Condensed Bold
+* Gill Sans Ultra Bold
+* Gloucester MT Extra Condensed
+* Goudy Old Style
+* Gulim
+* GulimChe
+* Gungsuh
+* GungsuhChe
+* HGGothicE
+* HGMaruGothicMPRO
+* HGMinchoE
+* HGPGothicE
+* HGPMinchoE
+* HGPSoeiKakugothicUB
+* HGSGothicE
+* HGSMinchoE
+* HGSSoeiKakugothicUB
+* HGSoeiKakugothicUB
+* Haettenschweiler
+* Harrington
+* Imprint MT Shadow
+* KaiTi
+* Kino MT
+* Lucida Blackletter
+* Lucida Bright
+* Lucida Calligraphy
+* Lucida Console
+* Lucida Fax
+* Lucida Handwriting
+* Lucida Sans
+* Lucida Sans Typewriter
+* Lucida Sans Unicode
+* MS Gothic
+* MS Mincho
+* MS PGothic
+* MS PMincho
+* MS Reference Sans Serif
+* MS Reference Specialty
+* MS UI Gothic
+* MT Extra
+* Malgun Gothic
+* Malgun Gothic Semilight
+* Marlett
+* Matura MT Script Capitals
+* Meiryo
+* Microsoft Himalaya
+* Microsoft JhengHei
+* Microsoft New Tai Lue
+* Microsoft Tai Le
+* Microsoft YaHei
+* Microsoft Yi Baiti
+* MingLiU
+* MingLiU-ExtB
+* MingLiU_HKSCS
+* MingLiU_HKSCS-ExtB
+* Mistral
+* Modern No. 20
+* Mongolian Baiti
+* Monotype Corsiva
+* Monotype Sorts
+* News Gothic MT
+* Onyx
+* PMingLiU
+* PMingLiU-ExtB
+* Palatino Linotype
+* Perpetua
+* Perpetua Titling MT
+* Rockwell
+* Rockwell Condensed
+* Rockwell Extra Bold
+* STHupo
+* STLiti
+* STXingkai
+* STXinwei
+* STZhongsong
+* Segoe Print
+* Segoe Script
+* SimHei
+* SimSun
+* SimSun-ExtB
+* Stencil
+* Tahoma
+* Trebuchet MS
+* Tw Cen MT
+* Tw Cen MT Condensed
+* Tw Cen MT Condensed Extra Bold
+* Verdana
+* Webdings
+* Wide Latin
+* Wingdings
+* Wingdings 2
+* Wingdings 3
+* Yu Gothic
+* Yu Gothic Light
+* Yu Gothic Medium
+* Yu Mincho
+</details>
+
+
+
+## Installing Office fonts
+
+Here's how to install "MS PGothic", "MS PMincho" and other Office fonts
+through Fontist.
+
+First update the collection of Fontist font formulas using the
+`fontist update` command:
+
+```sh
+$ fontist update
+Formulas have been successfully updated.
+```
+
+Now individual fonts can be installed by referring to their font names:
+
+```sh
+$ fontist install "MS PGothic"
+Fonts installed at:
+- /Users/john/.fontist/fonts/msgothic.ttc
+```
+
+Alternatively, all fonts from the same formula can be installed using the
+formula name:
+
+```sh
+$ fontist install --formula office_preview
+Fonts installed at:
+- /Users/john/.fontist/fonts/Rockwell Extra Bold.ttf
+- /Users/john/.fontist/fonts/webdings.ttf
+- /Users/john/.fontist/fonts/Dengb.ttf
+- /Users/john/.fontist/fonts/Candarai.ttf
+- /Users/john/.fontist/fonts/Cambria.ttc
+- /Users/john/.fontist/fonts/Verdana Bold.ttf
+- /Users/john/.fontist/fonts/GillSansUltraBold.ttf
+...
+```
+
+## Using Office fonts in continuous integration
+
+`fontist` supports flags that can be utilized in continuous integration (CI)
+systems.
+
+For instance:
+
+* The `--accept-all-licenses` flag allows the `install` command to install a
+font, while providing explicit acceptance through a command-line option.
+
+The `--force` flag ensures that `fontist` installs the font even if it's already
+present in the system, thereby guaranteeing its presence in the target path.
+
+```sh
+$ fontist install --accept-all-licenses --force "MS PGothic"
+```
+
+
+## Conclusion
+
+Fontist now supports a growing number of fonts and serve as a convenient
+method to install fonts programmatically, especially on continuous integration
+systems.
+
+Small announcement. A standalone package of `fontist` is currently in
+development. Soon, there would be even no need to install Ruby separately to
+use `fontist`.
+

--- a/src/content/blog/2024-02-29-new-websites-thanks-to-jacob.mdx
+++ b/src/content/blog/2024-02-29-new-websites-thanks-to-jacob.mdx
@@ -1,0 +1,70 @@
+---
+title: New Fontist sites contributed by Jacob!
+description: Expressing gratitude to Jacob Hummer for his outstanding contributions to Fontist's documentation and formula search sites.
+authors:
+  - Ronald Tse
+date: 2024-02-29
+---
+
+# New Fontist sites developed and deployed, contributed by Jacob Hummer
+
+
+
+The Fontist project has always been a community effort, and today we want to
+express our heartfelt thanks to [Jacob Hummer](https://github.com/jcbhmr)
+for his exceptional contributions to the Fontist ecosystem.
+
+## A significant contribution
+
+In early 2024, Jacob submitted two major pull requests that transformed
+how users interact with Fontist documentation:
+
+1. **[PR #358](https://github.com/fontist/fontist/pull/358)**: Host Fontist
+   documentation in-repo using VitePress — a complete documentation site with
+   2,621 lines of new code.
+
+2. **[PR #174](https://github.com/fontist/formulas/pull/174)**: Create a
+   searchable formulas website at [fontist.org/formulas/](https://www.fontist.org/formulas/) —
+   making it easy to discover and explore the 2,000+ font formulas available.
+
+## Why this matters
+
+Before Jacob's work, Fontist's documentation was scattered across multiple
+locations, making it harder for users to find the information they needed.
+Jacob consolidated everything into well-organized, searchable documentation
+sites using VitePress.
+
+His implementation includes:
+
+- **Full-text search** for all Fontist formulas
+- **Fully migrated documentation** from the previous site
+- **Individual formula pages** for each of the 2,000+ font formulas
+- **A clean, modern design**
+
+## The impact
+
+Thanks to Jacob's meticulous work, Fontist users can now:
+
+- Quickly find installation instructions and usage guides
+- Search through all available font formulas
+- Browse comprehensive API documentation
+- Contribute to documentation more easily
+
+Jacob describes himself as "a far too meticulous web developer" — and we
+certainly benefited from that attention to detail!
+
+## Thank you, Jacob!
+
+On behalf of the entire Fontist community, thank you Jacob for your
+generous contribution of time, expertise, and care. Your work has made
+Fontist significantly more accessible to everyone.
+
+If you appreciate Jacob's work as much as we do, you can find him on
+[GitHub](https://github.com/jcbhmr) or visit his website at
+[jcbhmr.com](https://jcbhmr.com/).
+
+---
+
+*Fontist thrives because of contributors like Jacob. If you're interested in
+contributing to Fontist, check out our
+[GitHub repositories](https://github.com/fontist) — we'd love to have you!*

--- a/src/content/blog/2024-02-29-new-websites-thanks-to-jacob.mdx.bak
+++ b/src/content/blog/2024-02-29-new-websites-thanks-to-jacob.mdx.bak
@@ -1,0 +1,70 @@
+---
+title: New Fontist sites contributed by Jacob!
+description: Expressing gratitude to Jacob Hummer for his outstanding contributions to Fontist's documentation and formula search sites.
+authors:
+  - Ronald Tse
+date: 2024-02-29
+---
+
+# New Fontist sites developed and deployed, contributed by Jacob Hummer
+
+<BlogByline />
+
+The Fontist project has always been a community effort, and today we want to
+express our heartfelt thanks to [Jacob Hummer](https://github.com/jcbhmr)
+for his exceptional contributions to the Fontist ecosystem.
+
+## A significant contribution
+
+In early 2024, Jacob submitted two major pull requests that transformed
+how users interact with Fontist documentation:
+
+1. **[PR #358](https://github.com/fontist/fontist/pull/358)**: Host Fontist
+   documentation in-repo using VitePress — a complete documentation site with
+   2,621 lines of new code.
+
+2. **[PR #174](https://github.com/fontist/formulas/pull/174)**: Create a
+   searchable formulas website at [fontist.org/formulas/](https://www.fontist.org/formulas/) —
+   making it easy to discover and explore the 2,000+ font formulas available.
+
+## Why this matters
+
+Before Jacob's work, Fontist's documentation was scattered across multiple
+locations, making it harder for users to find the information they needed.
+Jacob consolidated everything into well-organized, searchable documentation
+sites using VitePress.
+
+His implementation includes:
+
+- **Full-text search** for all Fontist formulas
+- **Fully migrated documentation** from the previous site
+- **Individual formula pages** for each of the 2,000+ font formulas
+- **A clean, modern design**
+
+## The impact
+
+Thanks to Jacob's meticulous work, Fontist users can now:
+
+- Quickly find installation instructions and usage guides
+- Search through all available font formulas
+- Browse comprehensive API documentation
+- Contribute to documentation more easily
+
+Jacob describes himself as "a far too meticulous web developer" — and we
+certainly benefited from that attention to detail!
+
+## Thank you, Jacob!
+
+On behalf of the entire Fontist community, thank you Jacob for your
+generous contribution of time, expertise, and care. Your work has made
+Fontist significantly more accessible to everyone.
+
+If you appreciate Jacob's work as much as we do, you can find him on
+[GitHub](https://github.com/jcbhmr) or visit his website at
+[jcbhmr.com](https://jcbhmr.com/).
+
+---
+
+*Fontist thrives because of contributors like Jacob. If you're interested in
+contributing to Fontist, check out our
+[GitHub repositories](https://github.com/fontist) — we'd love to have you!*

--- a/src/content/blog/2024-03-02-creating-formulas.mdx
+++ b/src/content/blog/2024-03-02-creating-formulas.mdx
@@ -1,0 +1,125 @@
+---
+title: Creating custom Fontist font formulas
+description: Easily create Fontist font formulas from font packages hosted online.
+authors:
+  - Ronald Tse
+  - Alexey Morozov
+date: 2024-03-02
+---
+
+# Creating custom Fontist font formulas
+
+
+
+Easily create Fontist font formulas from font packages hosted online.
+
+## Purpose
+
+Consider this scenario: you require a specific font for either your Continuous
+Integration system or your software.
+
+If the font is already available as a
+[Fontist font formula](https://www.fontist.org/formulas/),
+you can directly install that font.
+
+But what if *it's not there yet*?
+
+You can easily create a Fontist font formula from a *package hosted online*,
+even if it is complex and has an archive-in-archive structure.
+
+## Creating a Fontist font formula from a package
+
+First you need to create a formula providing a URL to an archive:
+
+```sh
+$ fontist create-formula http://example.com/archive.pkg
+some_font.yml formula has been successfully created
+```
+
+Then this formula should be placed in a formula repository, then the Fontist
+font formula index needs to be rebuilt:
+
+```sh
+$ cp some_font.yml ~/.fontist/versions/v3/formulas/Formulas/
+$ fontist rebuild-index
+```
+
+That's it! Now the fonts from the package can be installed and used:
+
+```sh
+$ fontist install "Some Font"
+Fonts installed at:
+- /Users/john/.fontist/fonts/some_font.ttf
+```
+
+## Contributing a Fontist font formula
+
+If the font formula you created is of a font that is openly licensed,
+please feel free to contribute it to the official
+[Fontist font formulas repository](https://github.com/fontist/formulas)
+so others could also use it.
+
+To do so, please create a Pull Request to the repository and add the formula
+YAML file (`*.yaml`) to it. A member of the Fontist team will then attend to
+the contribution as soon as we can.
+
+
+## Private font formulas
+
+If the font package in question is not to be shared online
+(such as a purchased, commercially-licensed font), Fontist supports
+[Custom Fontist repositories](https://github.com/fontist/fontist/#custom-fontist-repositories)
+to manage your own fonts and your own formulas.
+
+
+
+## Compression methods supported
+
+Fontist implements support for many compression methods, some of those
+not even readily available on popular OS platforms.
+
+Currently, Fontist supports decompression of files of the following archival
+methods commonly used for font packages:
+
+* [Cabinet / CAB](https://en.wikipedia.org/wiki/Cabinet_(file_format))
+  (extension: `*.cab`), the file format from Microsoft.
+* [cpio](https://en.wikipedia.org/wiki/Cpio) (extension: `*.cpio`),
+  the Unix "copy in and out" utility, defined in IEEE Std 1003.2 ("POSIX.2").
+* [ZIP](https://en.wikipedia.org/wiki/ZIP_(file_format)) (extension: `*.zip`)
+  and ZIP-based [self-extracting archives](https://en.wikipedia.org/wiki/Self-extracting_archives)
+  (extension: `*.exe`).
+* [gzip](https://en.wikipedia.org/wiki/Gzip) (extension: `*.gzip`) commonly used on Unix systems.
+* [OLE](https://en.wikipedia.org/wiki/Object_Linking_and_Embedding) from Microsoft
+  used in the packaging of the
+  [Windows Installer](https://en.wikipedia.org/wiki/Windows_Installer) archives
+  (extension: `*.msi`, `*.msp`).
+* [RPM](https://en.wikipedia.org/wiki/RPM_Package_Manager) (extension: `*.rpm`)
+  installation packages used on Linux systems.
+* [tar](https://en.wikipedia.org/wiki/Tar_(computing)) the Unix archival format.
+* [XAR](https://en.wikipedia.org/wiki/Xar_(archiver)) (extensions: `*.xar`, `*.pkg`, `*.xip`) from Apple,
+  [used in macOS installation packages and the App Store](https://forums.developer.apple.com/forums/thread/133985).
+
+Fontist relies on the [`excavate`](https://github.com/fontist/excavate/)
+Ruby library for decompression, with the latest list of supported compression
+methods available
+[here](https://github.com/fontist/excavate/blob/main/lib/excavate/archive.rb#L14).
+
+Fontist now also supports decompression of files through the comprehensive
+[`libarchive`](https://www.libarchive.org) library
+(the [Fontist version of libarchive in Ruby](https://github.com/fontist/ffi-libarchive-binary[ffi-libarchive])).
+This enhancement opens up the
+possibility of supporting a wider range of compression methods.
+
+
+# Conclusion
+
+Fontist now supports a growing number of fonts and can serve as a convenient
+method to install fonts programmatically, especially for continuous integration
+systems.
+
+{/* Small announcement. A standalone package of `fontist` is currently in
+development. Soon, there would be even no need to install Ruby separately to
+use `fontist`. */}
+
+Discover new fonts you can use with `fontist` and which packages you found
+online could be converted into font formulas.

--- a/src/content/blog/2024-03-02-creating-formulas.mdx.bak
+++ b/src/content/blog/2024-03-02-creating-formulas.mdx.bak
@@ -1,0 +1,126 @@
+---
+title: Creating custom Fontist font formulas
+description: Easily create Fontist font formulas from font packages hosted online.
+authors:
+  - Ronald Tse
+  - Alexey Morozov
+date: 2024-03-02
+---
+
+# Creating custom Fontist font formulas
+
+<BlogByline />
+
+Easily create Fontist font formulas from font packages hosted online.
+
+## Purpose
+
+Consider this scenario: you require a specific font for either your Continuous
+Integration system or your software.
+
+If the font is already available as a
+[Fontist font formula](https://www.fontist.org/formulas/),
+you can directly install that font.
+
+But what if *it's not there yet*?
+
+You can easily create a Fontist font formula from a *package hosted online*,
+even if it is complex and has an archive-in-archive structure.
+
+## Creating a Fontist font formula from a package
+
+First you need to create a formula providing a URL to an archive:
+
+```sh
+$ fontist create-formula http://example.com/archive.pkg
+some_font.yml formula has been successfully created
+```
+
+Then this formula should be placed in a formula repository, then the Fontist
+font formula index needs to be rebuilt:
+
+```sh
+$ cp some_font.yml ~/.fontist/versions/v3/formulas/Formulas/
+$ fontist rebuild-index
+```
+
+That's it! Now the fonts from the package can be installed and used:
+
+```sh
+$ fontist install "Some Font"
+Fonts installed at:
+- /Users/john/.fontist/fonts/some_font.ttf
+```
+
+## Contributing a Fontist font formula
+
+If the font formula you created is of a font that is openly licensed,
+please feel free to contribute it to the official
+[Fontist font formulas repository](https://github.com/fontist/formulas)
+so others could also use it.
+
+To do so, please create a Pull Request to the repository and add the formula
+YAML file (`*.yaml`) to it. A member of the Fontist team will then attend to
+the contribution as soon as we can.
+
+
+## Private font formulas
+
+If the font package in question is not to be shared online
+(such as a purchased, commercially-licensed font), Fontist supports
+[Custom Fontist repositories](https://github.com/fontist/fontist/#custom-fontist-repositories)
+to manage your own fonts and your own formulas.
+
+
+
+## Compression methods supported
+
+Fontist implements support for many compression methods, some of those
+not even readily available on popular OS platforms.
+
+Currently, Fontist supports decompression of files of the following archival
+methods commonly used for font packages:
+
+* [Cabinet / CAB](https://en.wikipedia.org/wiki/Cabinet_(file_format))
+  (extension: `*.cab`), the file format from Microsoft.
+* [cpio](https://en.wikipedia.org/wiki/Cpio) (extension: `*.cpio`),
+  the Unix "copy in and out" utility, defined in IEEE Std 1003.2 ("POSIX.2").
+* [ZIP](https://en.wikipedia.org/wiki/ZIP_(file_format)) (extension: `*.zip`)
+  and ZIP-based [self-extracting archives](https://en.wikipedia.org/wiki/Self-extracting_archives)
+  (extension: `*.exe`).
+* [gzip](https://en.wikipedia.org/wiki/Gzip) (extension: `*.gzip`) commonly used on Unix systems.
+* [OLE](https://en.wikipedia.org/wiki/Object_Linking_and_Embedding) from Microsoft
+  used in the packaging of the
+  [Windows Installer](https://en.wikipedia.org/wiki/Windows_Installer) archives
+  (extension: `*.msi`, `*.msp`).
+* [RPM](https://en.wikipedia.org/wiki/RPM_Package_Manager) (extension: `*.rpm`)
+  installation packages used on Linux systems.
+* [tar](https://en.wikipedia.org/wiki/Tar_(computing)) the Unix archival format.
+* [XAR](https://en.wikipedia.org/wiki/Xar_(archiver)) (extensions: `*.xar`, `*.pkg`, `*.xip`) from Apple,
+  [used in macOS installation packages and the App Store](https://forums.developer.apple.com/forums/thread/133985).
+
+Fontist relies on the [`excavate`](https://github.com/fontist/excavate/)
+Ruby library for decompression, with the latest list of supported compression
+methods available
+[here](https://github.com/fontist/excavate/blob/main/lib/excavate/archive.rb#L14).
+
+Fontist now also supports decompression of files through the comprehensive
+[`libarchive`](https://www.libarchive.org) library
+(the [Fontist version of libarchive in Ruby](https://github.com/fontist/ffi-libarchive-binary[ffi-libarchive])).
+This enhancement opens up the
+possibility of supporting a wider range of compression methods.
+
+
+# Conclusion
+
+Fontist now supports a growing number of fonts and can serve as a convenient
+method to install fonts programmatically, especially for continuous integration
+systems.
+
+<!-- Small announcement. A standalone package of `fontist` is currently in
+development. Soon, there would be even no need to install Ruby separately to
+use `fontist`.
+ -->
+
+Discover new fonts you can use with `fontist` and which packages you found
+online could be converted into font formulas.

--- a/src/content/blog/2026-03-12-unified-design-and-logo.mdx
+++ b/src/content/blog/2026-03-12-unified-design-and-logo.mdx
@@ -1,0 +1,90 @@
+---
+title: Introducing Fontist's New Unified Design and Logo
+description: All Fontist project sites now share a beautiful, consistent design with a distinctive new logo and carefully crafted color palette.
+authors:
+  - Ronald Tse
+date: 2026-03-12
+---
+
+# Introducing Fontist's New Unified Design and Logo
+
+
+
+All Fontist project sites have been redesigned with a unified visual identity.
+
+The new design features a distinctive logo and a carefully crafted rose/gray
+color palette that works beautifully across light and dark modes.
+
+## The new Fontist logo
+
+The Fontist logo embodies the intersection of typography, code, and utility.
+
+![New Fontist Logo](/logo-full.svg)
+
+## Design elements
+
+### **The Keycap Shape**
+
+The logo contains a keyboard keycap because typing is the primary way humans
+interact with fonts. Every **keystroke**, every message typed, every document, every
+line of code, imbues human intent into digital form. The keycap symbolizes this
+fundamental connection between human expression and digital typography.
+
+### **The Ruby "f"**
+
+The central **"f"** is rendered in [STIX Two Math](https://www.stixfonts.org/),
+a mathematical typeface. It represents the **abstract** beauty of computer fonts
+-- the abstract shapes of typography defined as mathematical curves. The
+elegance that emerges when typography meets computation. The ruby color reflects
+our passion and the precious value we place on open-source fonts, as well as the
+fact that Fontist was first created on Ruby, the object-oriented interpretive
+language.
+
+### **The Brackets "[..]"**
+
+Surrounding the "f" are brackets rendered in [Source Code](https://fonts.google.com/specimen/Source+Code+Pro),
+a monospace font.
+These represent **code** -- the enabler. They're in gray because while they
+don't demand attention, they quietly make everything possible. The brackets are
+in monospace font because Fontist is made for code and is code itself to support
+the usage of fonts. Code is the infrastructure upon which the beauty of fonts is
+delivered.
+
+## Color palette
+
+The brand colors were carefully chosen to create a distinctive aesthetic:
+
+* **Rose** (#bf4e6a) — Primary brand color, conveying warmth and approachability
+* **Rose Light** (#d4718a) — Accent color for light mode
+* **Dark** (#4d4b54) — Primary text color
+* **Gray** (#676565) — Secondary text and subtle elements
+
+Background accents use warm, natural tones: Cream (#e1dfd2), Beige (#bebbac),
+and Pale (#dddac8).
+
+A deliberate design choice was made to avoid blue and purple tones, giving
+Fontist a unique visual identity in the developer tools space.
+
+## Sites updated
+
+All Fontist project sites now share this unified design:
+
+* [Fontist.org](https://www.fontist.org/) — Main project hub with overview and documentation
+* [Fontist Documentation](https://www.fontist.org/fontist/) — Installation guides, CLI and API reference
+* [Fontisan Documentation](https://www.fontist.org/fontisan/) — Font analysis and metadata tool, CLI and API reference
+* [Font Formulas](https://www.fontist.org/formulas/) — Search over 2,000 font formulas
+
+## What's new
+
+The redesigned sites include these improvements:
+
+* **Light/dark mode** — Full theme support with smooth transitions between modes
+* **Responsive design** — Optimized layouts for mobile, tablet, and desktop viewing
+* **Accessibility** — Improved color contrast and semantic HTML throughout
+
+
+## Feedback
+
+We'd love to hear your feedback on the new design! Feel free to share your
+thoughts by opening an issue on the
+[Fontist GitHub repository](https://github.com/fontist/fontist.org/issues).

--- a/src/content/blog/2026-03-12-unified-design-and-logo.mdx.bak
+++ b/src/content/blog/2026-03-12-unified-design-and-logo.mdx.bak
@@ -1,0 +1,90 @@
+---
+title: Introducing Fontist's New Unified Design and Logo
+description: All Fontist project sites now share a beautiful, consistent design with a distinctive new logo and carefully crafted color palette.
+authors:
+  - Ronald Tse
+date: 2026-03-12
+---
+
+# Introducing Fontist's New Unified Design and Logo
+
+<BlogByline />
+
+All Fontist project sites have been redesigned with a unified visual identity.
+
+The new design features a distinctive logo and a carefully crafted rose/gray
+color palette that works beautifully across light and dark modes.
+
+## The new Fontist logo
+
+The Fontist logo embodies the intersection of typography, code, and utility.
+
+![New Fontist Logo](/logo-full.svg)
+
+## Design elements
+
+### **The Keycap Shape**
+
+The logo contains a keyboard keycap because typing is the primary way humans
+interact with fonts. Every **keystroke**, every message typed, every document, every
+line of code, imbues human intent into digital form. The keycap symbolizes this
+fundamental connection between human expression and digital typography.
+
+### **The Ruby "f"**
+
+The central **"f"** is rendered in [STIX Two Math](https://www.stixfonts.org/),
+a mathematical typeface. It represents the **abstract** beauty of computer fonts
+-- the abstract shapes of typography defined as mathematical curves. The
+elegance that emerges when typography meets computation. The ruby color reflects
+our passion and the precious value we place on open-source fonts, as well as the
+fact that Fontist was first created on Ruby, the object-oriented interpretive
+language.
+
+### **The Brackets "[..]"**
+
+Surrounding the "f" are brackets rendered in [Source Code](https://fonts.google.com/specimen/Source+Code+Pro),
+a monospace font.
+These represent **code** -- the enabler. They're in gray because while they
+don't demand attention, they quietly make everything possible. The brackets are
+in monospace font because Fontist is made for code and is code itself to support
+the usage of fonts. Code is the infrastructure upon which the beauty of fonts is
+delivered.
+
+## Color palette
+
+The brand colors were carefully chosen to create a distinctive aesthetic:
+
+* **Rose** (#bf4e6a) — Primary brand color, conveying warmth and approachability
+* **Rose Light** (#d4718a) — Accent color for light mode
+* **Dark** (#4d4b54) — Primary text color
+* **Gray** (#676565) — Secondary text and subtle elements
+
+Background accents use warm, natural tones: Cream (#e1dfd2), Beige (#bebbac),
+and Pale (#dddac8).
+
+A deliberate design choice was made to avoid blue and purple tones, giving
+Fontist a unique visual identity in the developer tools space.
+
+## Sites updated
+
+All Fontist project sites now share this unified design:
+
+* [Fontist.org](https://www.fontist.org/) — Main project hub with overview and documentation
+* [Fontist Documentation](https://www.fontist.org/fontist/) — Installation guides, CLI and API reference
+* [Fontisan Documentation](https://www.fontist.org/fontisan/) — Font analysis and metadata tool, CLI and API reference
+* [Font Formulas](https://www.fontist.org/formulas/) — Search over 2,000 font formulas
+
+## What's new
+
+The redesigned sites include these improvements:
+
+* **Light/dark mode** — Full theme support with smooth transitions between modes
+* **Responsive design** — Optimized layouts for mobile, tablet, and desktop viewing
+* **Accessibility** — Improved color contrast and semantic HTML throughout
+
+
+## Feedback
+
+We'd love to hear your feedback on the new design! Feel free to share your
+thoughts by opening an issue on the
+[Fontist GitHub repository](https://github.com/fontist/fontist.org/issues).

--- a/src/content/blog/2026-04-14-formula-v5.mdx
+++ b/src/content/blog/2026-04-14-formula-v5.mdx
@@ -1,0 +1,378 @@
+---
+title: "Fontist Formula v5: multi-format and variable font support"
+description: "Formula v5 adds explicit schema versioning, multi-format resources, variable font metadata, and import provenance for Fontist formulas."
+authors:
+  - Ronald Tse
+  - Hassan Akbar
+date: 2026-04-14
+---
+
+# Fontist Formula v5: multi-format and variable font support
+
+
+
+Fontist formulas have reached version 5.
+
+This release modernizes the formula schema for today's font ecosystem, where a
+single family can be available as desktop fonts, web fonts, static files,
+variable fonts, and source-specific system fonts.
+
+The main change is structural: Formula v5 describes what each resource contains
+instead of treating every formula as a single download with implicitly-known
+font files.
+
+## What formulas do
+
+A Fontist
+[font formula](https://www.fontist.org/formulas/)
+is a YAML file that tells Fontist where a font comes from, what files are
+available, and how those files map to installable font styles.
+
+Formula v4 worked well for the earlier Fontist model: most formulas described
+one downloadable package, usually an archive containing desktop font files.
+
+That model is no longer enough. Google Fonts, macOS supplementary fonts, SIL
+fonts, and other sources increasingly expose the same family through different
+file formats and different font technologies. Formula v5 adds the metadata
+Fontist needs to make those differences explicit.
+
+## From implicit to explicit
+
+Formula v4 did not declare its schema version. Formula v5 does:
+
+```yaml
+---
+schema_version: 5
+name: Courier Prime
+description: Courier Prime
+homepage: https://quoteunquoteapps.com
+```
+
+If `schema_version` is missing, Fontist continues to treat the formula as a v4
+formula. Existing private and custom formula repositories therefore keep
+working.
+
+The explicit version field matters because it gives Fontist a deterministic way
+to choose schema behavior. New fields can be added to v5 without changing how
+older formulas are interpreted.
+
+## Resources now describe formats
+
+In v4, a resource was usually named after the download itself:
+
+```yaml
+resources:
+  Courier_Prime.zip:
+    urls:
+    - https://quoteunquoteapps.com/courierprime/downloads/courier-prime.zip
+    sha256: d5d4faf1bee0d1f52bab1103cbfdfb354976331c86f999c110c22a098cb12d73
+    file_size: 193595
+```
+
+That structure is still valid for a migrated archive formula, but it does not
+tell Fontist what font format the resource provides.
+
+Formula v5 can describe resources by capability. For example, the Abel formula
+from Google Fonts provides static TTF and static WOFF2 resources:
+
+```yaml
+resources:
+  ttf_static:
+    source: google
+    family: Abel
+    files:
+    - https://fonts.gstatic.com/s/abel/v18/MwQ5bhbm2POE6VhLPJp6qGI.ttf
+    urls:
+    - https://fonts.gstatic.com/s/abel/v18/MwQ5bhbm2POE6VhLPJp6qGI.ttf
+    format: ttf
+  woff2_static:
+    source: google
+    family: Abel
+    files:
+    - https://fonts.gstatic.com/s/abel/v18/MwQ5bhbm2POE6V1LPJp6qGI.woff2
+    urls:
+    - https://fonts.gstatic.com/s/abel/v18/MwQ5bhbm2POE6V1LPJp6qGI.woff2
+    format: woff2
+```
+
+The important new field is `format`. A resource can now say whether it provides
+`ttf`, `otf`, `woff`, `woff2`, `ttc`, or `otc` files.
+
+Each resource carries both a `files` list and a `urls` list. For Google Fonts
+these are identical because each font file is downloaded directly by URL. For
+archive-based formulas like Courier Prime, `urls` points to the downloadable
+archive while `files` lists the font files extracted from within it.
+
+The resource name is also more meaningful. Names such as `ttf_static`,
+`woff2_static`, `ttf_variable`, and `woff2_variable` make it clear whether the
+resource is a desktop font, web font, static font, or variable font resource.
+
+## Styles know their available formats
+
+Formula v5 also records format information on each style:
+
+```yaml
+fonts:
+- name: Abel
+  styles:
+  - family_name: Abel
+    type: Regular
+    full_name: Abel Regular
+    post_script_name: Abel-Regular
+    font: MwQ5bhbm2POE6VhLPJp6qGI.ttf
+    formats:
+    - ttf
+    - woff2
+    variable_font: false
+```
+
+The `font` field is how a style connects to its resources: its value is a
+filename that appears in one of the resource `files` lists. The `formats` array
+then tells Fontist that the same style is available in other resources as well.
+In the example above, the `font` field references a `.ttf` filename found in
+the `ttf_static` resource, but the `formats` array also lists `woff2`,
+indicating that a WOFF2 version is available through the `woff2_static`
+resource.
+
+This means Fontist can tell that "Abel Regular" is available in both TTF and
+WOFF2. Users and tools can then request a format explicitly:
+
+```sh
+$ fontist install "Abel" --format woff2
+```
+
+When the user requests a specific format, Fontist first looks for a resource
+that already provides it. If no exact match exists, Fontist checks whether
+conversion from an available format is possible (for example, converting TTF to
+WOFF2). An exact-match resource is always preferred over conversion.
+
+## Variable font metadata
+
+Variable fonts are one of the main reasons for Formula v5.
+
+A variable font can contain a range of designs in a single font file. Instead
+of installing separate files for Regular, Bold, Condensed, or other fixed
+instances, a variable font exposes axes such as weight (`wght`), width (`wdth`),
+slant (`slnt`), or optical size (`opsz`).
+
+Formula v5 represents this with `variable_font` and `variable_axes`.
+
+Roboto Flex is a good example. (The `HASH` placeholders below stand in for
+the long hashed filenames that Google Fonts uses.)
+
+```yaml
+resources:
+  woff2_variable:
+    source: google
+    family: Roboto Flex
+    files:
+    - https://fonts.gstatic.com/s/robotoflex/v30/HASH.woff2
+    urls:
+    - https://fonts.gstatic.com/s/robotoflex/v30/HASH.woff2
+    format: woff2
+    variable_axes:
+    - GRAD
+    - XOPQ
+    - XTRA
+    - YOPQ
+    - YTAS
+    - YTDE
+    - YTFI
+    - YTLC
+    - YTUC
+    - opsz
+    - slnt
+    - wdth
+    - wght
+  ttf_variable:
+    source: google
+    family: Roboto Flex
+    files:
+    - https://fonts.gstatic.com/s/robotoflex/v30/HASH.ttf
+    urls:
+    - https://fonts.gstatic.com/s/robotoflex/v30/HASH.ttf
+    format: ttf
+    variable_axes:
+    - GRAD
+    - XOPQ
+    - XTRA
+    - YOPQ
+    - YTAS
+    - YTDE
+    - YTFI
+    - YTLC
+    - YTUC
+    - opsz
+    - slnt
+    - wdth
+    - wght
+```
+
+The same metadata is available on styles. Notice that `font` references a
+`.ttf` filename from the `ttf_variable` resource, while `formats` declares that
+WOFF2 is also available:
+
+```yaml
+fonts:
+- name: Roboto Flex
+  styles:
+  - family_name: Roboto Flex
+    type: Regular
+    font: HASH.ttf  # filename from ttf_variable resource
+    formats:
+    - ttf
+    - woff2
+    variable_font: true
+    variable_axes:
+    - GRAD
+    - XOPQ
+    - XTRA
+    - YOPQ
+    - YTAS
+    - YTDE
+    - YTFI
+    - YTLC
+    - YTUC
+    - opsz
+    - slnt
+    - wdth
+    - wght
+```
+
+The `variable_axes` array appears on both resources and styles. They serve
+different purposes: on a resource, axes describe what the font file physically
+contains. On a style, axes describe what is available to the user across all
+resources for that style. Style-level axes are derived automatically during
+import and migration, so they stay in sync with the underlying resources.
+
+In practice the two lists are usually identical, but they can diverge when
+resources for the same style offer different axis sets. When that happens and a
+user requests specific axes, Fontist selects the resource that satisfies the
+request.
+
+This enables capability-based workflows:
+
+```sh
+$ fontist find --variable
+$ fontist find --axes wght,wdth
+$ fontist install "Roboto Flex" --variable-axes wght,wdth
+$ fontist install "Roboto Flex" --prefer-variable
+```
+
+Fontist can now answer questions such as "which fonts support weight and width
+axes?" and "install the variable version when one is available."
+
+## Import provenance
+
+Formula v5 can record where an imported formula came from.
+
+The `import_source` field is typed by source. For macOS supplementary fonts, it
+tracks the framework version, posting date, and asset ID:
+
+```yaml
+import_source:
+  type: macos
+  framework_version: 8
+  posted_date: '2025-08-05T18:58:57Z'
+  asset_id: 10m11177
+```
+
+Google and SIL formulas can carry source-specific metadata as well:
+
+```yaml
+import_source:
+  type: google
+  commit_id: abc123def456
+  api_version: v1
+  last_modified: '2026-04-01T00:00:00Z'
+  family_id: roboto-flex
+```
+
+```yaml
+import_source:
+  type: sil
+  version: 6.200
+  release_date: '2024-02-01'
+```
+
+Windows Features on Demand (FOD) formulas track the Windows capability name and
+minimum version:
+
+```yaml
+import_source:
+  type: windows
+  capability_name: Language.Fonts.Jpan~~~und-JPAN~0.0.1.0
+  min_windows_version: "10.0"
+```
+
+This improves auditing and update detection. Fontist can distinguish formulas
+that came from different upstream sources and can compare source metadata when
+checking whether an imported formula is outdated. For example:
+
+```sh
+$ fontist check-updates --source google
+Outdated formulas:
+  roboto_flex: local commit abc123, upstream commit def456
+  abel: up to date
+```
+
+Without `import_source`, Fontist would have no way to tell whether a formula's
+upstream has moved ahead.
+
+## Structural comparison
+
+| Aspect | Formula v4 | Formula v5 |
+|---|---|---|
+| Schema version | Implicit | Explicit `schema_version: 5` |
+| Resource model | Usually one package or archive | Multiple resources by capability |
+| Resource format | Inferred from files | Declared with `format` |
+| Style format metadata | Not available | Declared with `formats` |
+| Variable fonts | Not represented | `variable_font` and `variable_axes` |
+| Capability search | Limited to formula/style names | Can filter by format, variable font support, and axes |
+| Import provenance | Not represented | Typed `import_source` metadata |
+
+## What this enables
+
+Formula v5 gives Fontist a richer view of each font family.
+
+For desktop use, Fontist can still install TTF or OTF files as before. For web
+projects, it can choose WOFF2 resources where they are available. For modern
+typography workflows, it can find and install variable fonts by supported axes.
+
+The new structure also helps formula maintainers. Imported formulas can record
+their upstream source, and migrated formulas can preserve their existing
+installation behavior while gaining an explicit schema version.
+
+## Migration
+
+The official Fontist formulas repository has been migrated to v5. The current
+repository contains more than 4,000 formula files, including Google Fonts,
+macOS supplementary fonts, Windows FOD fonts, SIL fonts, and
+manually-maintained formulas.
+
+For formula maintainers, the recommended path depends on the source:
+
+* Re-import generated formula sets such as Google Fonts, macOS fonts, and SIL
+  fonts with `--schema-version=5`.
+* Use the migration command for custom or manually-maintained formulas.
+
+```sh
+$ fontist migrate-formulas ./Formulas ./output --dry-run
+```
+
+The migration keeps v4 compatibility in mind. A formula without
+`schema_version` is still treated as v4, and existing custom formulas continue
+to work.
+
+## Conclusion
+
+Formula v5 makes Fontist formulas explicit about the font capabilities they
+describe.
+
+Instead of assuming one resource and one desktop-oriented format, formulas can
+now declare multiple formats, identify variable font resources, list supported
+axes, and record where imported metadata came from.
+
+That structure gives Fontist the foundation for better format selection,
+variable font discovery, source auditing, and future schema evolution while
+preserving compatibility with existing v4 formulas.

--- a/src/content/blog/2026-04-14-formula-v5.mdx.bak
+++ b/src/content/blog/2026-04-14-formula-v5.mdx.bak
@@ -1,0 +1,378 @@
+---
+title: "Fontist Formula v5: multi-format and variable font support"
+description: "Formula v5 adds explicit schema versioning, multi-format resources, variable font metadata, and import provenance for Fontist formulas."
+authors:
+  - Ronald Tse
+  - Hassan Akbar
+date: 2026-04-14
+---
+
+# Fontist Formula v5: multi-format and variable font support
+
+<BlogByline />
+
+Fontist formulas have reached version 5.
+
+This release modernizes the formula schema for today's font ecosystem, where a
+single family can be available as desktop fonts, web fonts, static files,
+variable fonts, and source-specific system fonts.
+
+The main change is structural: Formula v5 describes what each resource contains
+instead of treating every formula as a single download with implicitly-known
+font files.
+
+## What formulas do
+
+A Fontist
+[font formula](https://www.fontist.org/formulas/)
+is a YAML file that tells Fontist where a font comes from, what files are
+available, and how those files map to installable font styles.
+
+Formula v4 worked well for the earlier Fontist model: most formulas described
+one downloadable package, usually an archive containing desktop font files.
+
+That model is no longer enough. Google Fonts, macOS supplementary fonts, SIL
+fonts, and other sources increasingly expose the same family through different
+file formats and different font technologies. Formula v5 adds the metadata
+Fontist needs to make those differences explicit.
+
+## From implicit to explicit
+
+Formula v4 did not declare its schema version. Formula v5 does:
+
+```yaml
+---
+schema_version: 5
+name: Courier Prime
+description: Courier Prime
+homepage: https://quoteunquoteapps.com
+```
+
+If `schema_version` is missing, Fontist continues to treat the formula as a v4
+formula. Existing private and custom formula repositories therefore keep
+working.
+
+The explicit version field matters because it gives Fontist a deterministic way
+to choose schema behavior. New fields can be added to v5 without changing how
+older formulas are interpreted.
+
+## Resources now describe formats
+
+In v4, a resource was usually named after the download itself:
+
+```yaml
+resources:
+  Courier_Prime.zip:
+    urls:
+    - https://quoteunquoteapps.com/courierprime/downloads/courier-prime.zip
+    sha256: d5d4faf1bee0d1f52bab1103cbfdfb354976331c86f999c110c22a098cb12d73
+    file_size: 193595
+```
+
+That structure is still valid for a migrated archive formula, but it does not
+tell Fontist what font format the resource provides.
+
+Formula v5 can describe resources by capability. For example, the Abel formula
+from Google Fonts provides static TTF and static WOFF2 resources:
+
+```yaml
+resources:
+  ttf_static:
+    source: google
+    family: Abel
+    files:
+    - https://fonts.gstatic.com/s/abel/v18/MwQ5bhbm2POE6VhLPJp6qGI.ttf
+    urls:
+    - https://fonts.gstatic.com/s/abel/v18/MwQ5bhbm2POE6VhLPJp6qGI.ttf
+    format: ttf
+  woff2_static:
+    source: google
+    family: Abel
+    files:
+    - https://fonts.gstatic.com/s/abel/v18/MwQ5bhbm2POE6V1LPJp6qGI.woff2
+    urls:
+    - https://fonts.gstatic.com/s/abel/v18/MwQ5bhbm2POE6V1LPJp6qGI.woff2
+    format: woff2
+```
+
+The important new field is `format`. A resource can now say whether it provides
+`ttf`, `otf`, `woff`, `woff2`, `ttc`, or `otc` files.
+
+Each resource carries both a `files` list and a `urls` list. For Google Fonts
+these are identical because each font file is downloaded directly by URL. For
+archive-based formulas like Courier Prime, `urls` points to the downloadable
+archive while `files` lists the font files extracted from within it.
+
+The resource name is also more meaningful. Names such as `ttf_static`,
+`woff2_static`, `ttf_variable`, and `woff2_variable` make it clear whether the
+resource is a desktop font, web font, static font, or variable font resource.
+
+## Styles know their available formats
+
+Formula v5 also records format information on each style:
+
+```yaml
+fonts:
+- name: Abel
+  styles:
+  - family_name: Abel
+    type: Regular
+    full_name: Abel Regular
+    post_script_name: Abel-Regular
+    font: MwQ5bhbm2POE6VhLPJp6qGI.ttf
+    formats:
+    - ttf
+    - woff2
+    variable_font: false
+```
+
+The `font` field is how a style connects to its resources: its value is a
+filename that appears in one of the resource `files` lists. The `formats` array
+then tells Fontist that the same style is available in other resources as well.
+In the example above, the `font` field references a `.ttf` filename found in
+the `ttf_static` resource, but the `formats` array also lists `woff2`,
+indicating that a WOFF2 version is available through the `woff2_static`
+resource.
+
+This means Fontist can tell that "Abel Regular" is available in both TTF and
+WOFF2. Users and tools can then request a format explicitly:
+
+```sh
+$ fontist install "Abel" --format woff2
+```
+
+When the user requests a specific format, Fontist first looks for a resource
+that already provides it. If no exact match exists, Fontist checks whether
+conversion from an available format is possible (for example, converting TTF to
+WOFF2). An exact-match resource is always preferred over conversion.
+
+## Variable font metadata
+
+Variable fonts are one of the main reasons for Formula v5.
+
+A variable font can contain a range of designs in a single font file. Instead
+of installing separate files for Regular, Bold, Condensed, or other fixed
+instances, a variable font exposes axes such as weight (`wght`), width (`wdth`),
+slant (`slnt`), or optical size (`opsz`).
+
+Formula v5 represents this with `variable_font` and `variable_axes`.
+
+Roboto Flex is a good example. (The `HASH` placeholders below stand in for
+the long hashed filenames that Google Fonts uses.)
+
+```yaml
+resources:
+  woff2_variable:
+    source: google
+    family: Roboto Flex
+    files:
+    - https://fonts.gstatic.com/s/robotoflex/v30/HASH.woff2
+    urls:
+    - https://fonts.gstatic.com/s/robotoflex/v30/HASH.woff2
+    format: woff2
+    variable_axes:
+    - GRAD
+    - XOPQ
+    - XTRA
+    - YOPQ
+    - YTAS
+    - YTDE
+    - YTFI
+    - YTLC
+    - YTUC
+    - opsz
+    - slnt
+    - wdth
+    - wght
+  ttf_variable:
+    source: google
+    family: Roboto Flex
+    files:
+    - https://fonts.gstatic.com/s/robotoflex/v30/HASH.ttf
+    urls:
+    - https://fonts.gstatic.com/s/robotoflex/v30/HASH.ttf
+    format: ttf
+    variable_axes:
+    - GRAD
+    - XOPQ
+    - XTRA
+    - YOPQ
+    - YTAS
+    - YTDE
+    - YTFI
+    - YTLC
+    - YTUC
+    - opsz
+    - slnt
+    - wdth
+    - wght
+```
+
+The same metadata is available on styles. Notice that `font` references a
+`.ttf` filename from the `ttf_variable` resource, while `formats` declares that
+WOFF2 is also available:
+
+```yaml
+fonts:
+- name: Roboto Flex
+  styles:
+  - family_name: Roboto Flex
+    type: Regular
+    font: HASH.ttf  # filename from ttf_variable resource
+    formats:
+    - ttf
+    - woff2
+    variable_font: true
+    variable_axes:
+    - GRAD
+    - XOPQ
+    - XTRA
+    - YOPQ
+    - YTAS
+    - YTDE
+    - YTFI
+    - YTLC
+    - YTUC
+    - opsz
+    - slnt
+    - wdth
+    - wght
+```
+
+The `variable_axes` array appears on both resources and styles. They serve
+different purposes: on a resource, axes describe what the font file physically
+contains. On a style, axes describe what is available to the user across all
+resources for that style. Style-level axes are derived automatically during
+import and migration, so they stay in sync with the underlying resources.
+
+In practice the two lists are usually identical, but they can diverge when
+resources for the same style offer different axis sets. When that happens and a
+user requests specific axes, Fontist selects the resource that satisfies the
+request.
+
+This enables capability-based workflows:
+
+```sh
+$ fontist find --variable
+$ fontist find --axes wght,wdth
+$ fontist install "Roboto Flex" --variable-axes wght,wdth
+$ fontist install "Roboto Flex" --prefer-variable
+```
+
+Fontist can now answer questions such as "which fonts support weight and width
+axes?" and "install the variable version when one is available."
+
+## Import provenance
+
+Formula v5 can record where an imported formula came from.
+
+The `import_source` field is typed by source. For macOS supplementary fonts, it
+tracks the framework version, posting date, and asset ID:
+
+```yaml
+import_source:
+  type: macos
+  framework_version: 8
+  posted_date: '2025-08-05T18:58:57Z'
+  asset_id: 10m11177
+```
+
+Google and SIL formulas can carry source-specific metadata as well:
+
+```yaml
+import_source:
+  type: google
+  commit_id: abc123def456
+  api_version: v1
+  last_modified: '2026-04-01T00:00:00Z'
+  family_id: roboto-flex
+```
+
+```yaml
+import_source:
+  type: sil
+  version: 6.200
+  release_date: '2024-02-01'
+```
+
+Windows Features on Demand (FOD) formulas track the Windows capability name and
+minimum version:
+
+```yaml
+import_source:
+  type: windows
+  capability_name: Language.Fonts.Jpan~~~und-JPAN~0.0.1.0
+  min_windows_version: "10.0"
+```
+
+This improves auditing and update detection. Fontist can distinguish formulas
+that came from different upstream sources and can compare source metadata when
+checking whether an imported formula is outdated. For example:
+
+```sh
+$ fontist check-updates --source google
+Outdated formulas:
+  roboto_flex: local commit abc123, upstream commit def456
+  abel: up to date
+```
+
+Without `import_source`, Fontist would have no way to tell whether a formula's
+upstream has moved ahead.
+
+## Structural comparison
+
+| Aspect | Formula v4 | Formula v5 |
+|---|---|---|
+| Schema version | Implicit | Explicit `schema_version: 5` |
+| Resource model | Usually one package or archive | Multiple resources by capability |
+| Resource format | Inferred from files | Declared with `format` |
+| Style format metadata | Not available | Declared with `formats` |
+| Variable fonts | Not represented | `variable_font` and `variable_axes` |
+| Capability search | Limited to formula/style names | Can filter by format, variable font support, and axes |
+| Import provenance | Not represented | Typed `import_source` metadata |
+
+## What this enables
+
+Formula v5 gives Fontist a richer view of each font family.
+
+For desktop use, Fontist can still install TTF or OTF files as before. For web
+projects, it can choose WOFF2 resources where they are available. For modern
+typography workflows, it can find and install variable fonts by supported axes.
+
+The new structure also helps formula maintainers. Imported formulas can record
+their upstream source, and migrated formulas can preserve their existing
+installation behavior while gaining an explicit schema version.
+
+## Migration
+
+The official Fontist formulas repository has been migrated to v5. The current
+repository contains more than 4,000 formula files, including Google Fonts,
+macOS supplementary fonts, Windows FOD fonts, SIL fonts, and
+manually-maintained formulas.
+
+For formula maintainers, the recommended path depends on the source:
+
+* Re-import generated formula sets such as Google Fonts, macOS fonts, and SIL
+  fonts with `--schema-version=5`.
+* Use the migration command for custom or manually-maintained formulas.
+
+```sh
+$ fontist migrate-formulas ./Formulas ./output --dry-run
+```
+
+The migration keeps v4 compatibility in mind. A formula without
+`schema_version` is still treated as v4, and existing custom formulas continue
+to work.
+
+## Conclusion
+
+Formula v5 makes Fontist formulas explicit about the font capabilities they
+describe.
+
+Instead of assuming one resource and one desktop-oriented format, formulas can
+now declare multiple formats, identify variable font resources, list supported
+axes, and record where imported metadata came from.
+
+That structure gives Fontist the foundation for better format selection,
+variable font discovery, source auditing, and future schema evolution while
+preserving compatibility with existing v4 formulas.

--- a/src/content/blog/2026-05-03-windows-fod-fonts.mdx
+++ b/src/content/blog/2026-05-03-windows-fod-fonts.mdx
@@ -1,0 +1,316 @@
+---
+title: "Installing Windows supplementary fonts with Features on Demand"
+description: "Fontist 3.0 can install over 100 Windows supplementary fonts — Japanese, Korean, Pan-European, and more — using Windows Features on Demand, automatically via PowerShell."
+authors:
+  - Ronald Tse
+date: 2026-05-03
+---
+
+# Installing Windows supplementary fonts with Features on Demand
+
+
+
+Windows 10 and 11 ship with a large catalog of fonts, but many are not
+installed by default. These supplementary fonts — covering Japanese, Korean,
+Chinese, Arabic, Hebrew, Thai, Pan-European, and many other scripts — are
+available as Features on Demand (FOD) but require manual installation through
+Settings or PowerShell.
+
+Fontist 3.0 now installs these fonts automatically. A single command is all it
+takes:
+
+```sh
+$ fontist install "Meiryo"
+```
+
+## The problem
+
+Windows does not install all available fonts by default to save disk space.
+Fonts like Meiryo (Japanese), Batang (Korean), Arial Nova (Pan-European), and
+Plantagenet Cherokee are available as optional Features on Demand but require
+either navigating through Windows Settings or running PowerShell commands with
+admin privileges.
+
+For CI pipelines running on Windows, this is especially inconvenient.
+Documents that reference these fonts fail to render correctly when the fonts
+are missing.
+
+## How it works
+
+When you install a Windows FOD font through Fontist, it:
+
+1. Checks whether the required Windows capability is already installed using
+   `Get-WindowsCapability`
+2. If not present, installs it using `Add-WindowsCapability -Online`
+3. Verifies the font files are now available in `C:\Windows\Fonts\`
+
+This uses the Formula v5 schema with a `source: windows_fod` resource type,
+which tells Fontist to handle installation through the operating system rather
+than downloading an archive.
+
+## Installing a font
+
+Install any Windows FOD font by name:
+
+```sh
+$ fontist install "Meiryo"
+```
+
+```sh
+$ fontist install "Arial Nova"
+```
+
+```sh
+$ fontist install "Plantagenet Cherokee"
+```
+
+Use `--accept-all-licenses` for non-interactive installs:
+
+```sh
+$ fontist install "Meiryo" --accept-all-licenses
+```
+
+## Using in CI
+
+On GitHub Actions Windows runners, FOD font installation works out of the box
+since the runners have admin privileges:
+
+```yaml
+- name: Install fonts
+  run: gem install fontist && fontist install "Meiryo" --accept-all-licenses
+  shell: pwsh
+```
+
+## Requirements
+
+- Windows 10 (version 1607) or later
+- Administrator privileges (required by `Add-WindowsCapability`)
+- Internet connectivity (Windows downloads the font capability on first install)
+
+To check which FOD font capabilities are available on your system, run:
+
+```powershell
+Get-WindowsCapability -Online -Name "Language.Fonts.*"
+```
+
+## Available fonts
+
+Fontist supports 24 Windows FOD capability groups containing 100 font families.
+
+<details>
+<summary>Click to expand the full list</summary>
+
+### Arabic Script Supplemental Fonts
+
+- Aldhabi
+- Andalus
+- Arabic Typesetting
+- Microsoft Uighur
+- Sakkal Majalla
+- Simplified Arabic
+- Simplified Arabic Fixed
+- Traditional Arabic
+- Urdu Typesetting
+
+### Bangla Script Supplemental Fonts
+
+- Shonar Bangla
+- Vrinda
+
+### Canadian Aboriginal Syllabics Supplemental Fonts
+
+- Euphemia
+
+### Cherokee Supplemental Fonts
+
+- Plantagenet Cherokee
+
+### Chinese (Simplified) Supplemental Fonts
+
+- DengXian
+- FangSong
+- KaiTi
+- SimHei
+
+### Chinese (Traditional) Supplemental Fonts
+
+- DFKai-SB
+- MingLiU
+- MingLiU_HKSCS
+- PMingLiU
+
+### Devanagari Supplemental Fonts
+
+- Aparajita
+- Kokila
+- Mangal
+- Sanskrit Text
+- Utsaah
+
+### Ethiopic Supplemental Fonts
+
+- Nyala
+
+### Gujarati Supplemental Fonts
+
+- Shruti
+
+### Gurmukhi Supplemental Fonts
+
+- Raavi
+
+### Hebrew Supplemental Fonts
+
+- Aharoni Bold
+- David
+- FrankRuehl
+- Gisha
+- Levenim MT
+- Miriam
+- Miriam Fixed
+- Narkisim
+- Rod
+
+### Japanese Supplemental Fonts
+
+- BIZ UDGothic
+- BIZ UDPGothic
+- BIZ UDMincho Medium
+- BIZ UDPMincho Medium
+- Meiryo
+- Meiryo UI
+- MS Mincho
+- MS PMincho
+- UD Digi Kyokasho N-B
+- UD Digi Kyokasho NK-B
+- UD Digi Kyokasho NK-R
+- UD Digi Kyokasho NP-B
+- UD Digi Kyokasho NP-R
+- UD Digi Kyokasho N-R
+- Yu Mincho
+
+### Kannada Supplemental Fonts
+
+- Tunga
+
+### Khmer Supplemental Fonts
+
+- DaunPenh
+- Khmer UI
+- MoolBoran
+
+### Korean Supplemental Fonts
+
+- Batang
+- BatangChe
+- Dotum
+- DotumChe
+- Gulim
+- GulimChe
+- Gungsuh
+- GungsuhChe
+
+### Lao Supplemental Fonts
+
+- DokChampa
+- Lao UI
+
+### Malayalam Supplemental Fonts
+
+- Kartika
+
+### Odia Supplemental Fonts
+
+- Kalinga
+
+### Pan-European Supplemental Fonts
+
+- Arial Nova
+- Arial Nova Cond
+- Georgia Pro
+- Georgia Pro Cond
+- Gill Sans Nova
+- Gill Sans Nova Cond
+- Neue Haas Grotesk Text Pro
+- Rockwell Nova
+- Rockwell Nova Cond
+- Verdana Pro
+- Verdana Pro Cond
+
+### Sinhala Supplemental Fonts
+
+- Iskoola Pota
+
+### Syriac Supplemental Fonts
+
+- Estrangelo Edessa
+
+### Tamil Supplemental Fonts
+
+- Latha
+- Vijaya
+
+### Telugu Supplemental Fonts
+
+- Gautami
+- Vani
+
+### Thai Supplemental Fonts
+
+- Angsana New
+- AngsanaUPC
+- Browallia New
+- BrowalliaUPC
+- Cordia New
+- CordiaUPC
+- DilleniaUPC
+- EucrosiaUPC
+- FreesiaUPC
+- IrisUPC
+- JasmineUPC
+- KodchiangUPC
+- Leelawadee
+- LilyUPC
+
+</details>
+
+## What else is new in Fontist 3.0
+
+Windows FOD support is part of the Fontist 3.0 release, which also includes
+these improvements:
+
+**Formula v5 schema.**
+Formulas now support multiple font formats (TTF, OTF, WOFF2), variable font
+metadata, and import provenance. See our earlier post on Formula v5 for the full details.
+
+**Platform-aware font selection.**
+Manifests now validate operating system compatibility before attempting to
+install platform-specific fonts, preventing errors when a font is only
+available on one platform.
+
+**Skip license prompts for already-installed fonts.**
+If a font is already present on the current operating system, Fontist skips the
+license confirmation step, reducing friction when re-running installations.
+
+**Lazy formulas initialization.**
+The formulas repository is no longer cloned at startup. Fontist defers this
+until the first operation that actually needs formulas, making initial startup
+faster.
+
+**Index rebuild speedup.**
+The index rebuild process has been optimized for large formula repositories,
+reducing the time needed to refresh the font index.
+
+## Conclusion
+
+Windows FOD font support rounds out Fontist's platform coverage. Together with
+macOS supplementary fonts, Google Fonts, SIL fonts, and Microsoft Office fonts,
+Fontist now provides automated installation of openly-licensed fonts across all
+major platforms.
+
+Install Fontist and try it:
+
+```sh
+$ gem install fontist
+$ fontist install "Meiryo"
+```

--- a/src/content/blog/2026-05-03-windows-fod-fonts.mdx.bak
+++ b/src/content/blog/2026-05-03-windows-fod-fonts.mdx.bak
@@ -1,0 +1,316 @@
+---
+title: "Installing Windows supplementary fonts with Features on Demand"
+description: "Fontist 3.0 can install over 100 Windows supplementary fonts — Japanese, Korean, Pan-European, and more — using Windows Features on Demand, automatically via PowerShell."
+authors:
+  - Ronald Tse
+date: 2026-05-03
+---
+
+# Installing Windows supplementary fonts with Features on Demand
+
+<BlogByline />
+
+Windows 10 and 11 ship with a large catalog of fonts, but many are not
+installed by default. These supplementary fonts — covering Japanese, Korean,
+Chinese, Arabic, Hebrew, Thai, Pan-European, and many other scripts — are
+available as Features on Demand (FOD) but require manual installation through
+Settings or PowerShell.
+
+Fontist 3.0 now installs these fonts automatically. A single command is all it
+takes:
+
+```sh
+$ fontist install "Meiryo"
+```
+
+## The problem
+
+Windows does not install all available fonts by default to save disk space.
+Fonts like Meiryo (Japanese), Batang (Korean), Arial Nova (Pan-European), and
+Plantagenet Cherokee are available as optional Features on Demand but require
+either navigating through Windows Settings or running PowerShell commands with
+admin privileges.
+
+For CI pipelines running on Windows, this is especially inconvenient.
+Documents that reference these fonts fail to render correctly when the fonts
+are missing.
+
+## How it works
+
+When you install a Windows FOD font through Fontist, it:
+
+1. Checks whether the required Windows capability is already installed using
+   `Get-WindowsCapability`
+2. If not present, installs it using `Add-WindowsCapability -Online`
+3. Verifies the font files are now available in `C:\Windows\Fonts\`
+
+This uses the Formula v5 schema with a `source: windows_fod` resource type,
+which tells Fontist to handle installation through the operating system rather
+than downloading an archive.
+
+## Installing a font
+
+Install any Windows FOD font by name:
+
+```sh
+$ fontist install "Meiryo"
+```
+
+```sh
+$ fontist install "Arial Nova"
+```
+
+```sh
+$ fontist install "Plantagenet Cherokee"
+```
+
+Use `--accept-all-licenses` for non-interactive installs:
+
+```sh
+$ fontist install "Meiryo" --accept-all-licenses
+```
+
+## Using in CI
+
+On GitHub Actions Windows runners, FOD font installation works out of the box
+since the runners have admin privileges:
+
+```yaml
+- name: Install fonts
+  run: gem install fontist && fontist install "Meiryo" --accept-all-licenses
+  shell: pwsh
+```
+
+## Requirements
+
+- Windows 10 (version 1607) or later
+- Administrator privileges (required by `Add-WindowsCapability`)
+- Internet connectivity (Windows downloads the font capability on first install)
+
+To check which FOD font capabilities are available on your system, run:
+
+```powershell
+Get-WindowsCapability -Online -Name "Language.Fonts.*"
+```
+
+## Available fonts
+
+Fontist supports 24 Windows FOD capability groups containing 100 font families.
+
+<details>
+<summary>Click to expand the full list</summary>
+
+### Arabic Script Supplemental Fonts
+
+- Aldhabi
+- Andalus
+- Arabic Typesetting
+- Microsoft Uighur
+- Sakkal Majalla
+- Simplified Arabic
+- Simplified Arabic Fixed
+- Traditional Arabic
+- Urdu Typesetting
+
+### Bangla Script Supplemental Fonts
+
+- Shonar Bangla
+- Vrinda
+
+### Canadian Aboriginal Syllabics Supplemental Fonts
+
+- Euphemia
+
+### Cherokee Supplemental Fonts
+
+- Plantagenet Cherokee
+
+### Chinese (Simplified) Supplemental Fonts
+
+- DengXian
+- FangSong
+- KaiTi
+- SimHei
+
+### Chinese (Traditional) Supplemental Fonts
+
+- DFKai-SB
+- MingLiU
+- MingLiU_HKSCS
+- PMingLiU
+
+### Devanagari Supplemental Fonts
+
+- Aparajita
+- Kokila
+- Mangal
+- Sanskrit Text
+- Utsaah
+
+### Ethiopic Supplemental Fonts
+
+- Nyala
+
+### Gujarati Supplemental Fonts
+
+- Shruti
+
+### Gurmukhi Supplemental Fonts
+
+- Raavi
+
+### Hebrew Supplemental Fonts
+
+- Aharoni Bold
+- David
+- FrankRuehl
+- Gisha
+- Levenim MT
+- Miriam
+- Miriam Fixed
+- Narkisim
+- Rod
+
+### Japanese Supplemental Fonts
+
+- BIZ UDGothic
+- BIZ UDPGothic
+- BIZ UDMincho Medium
+- BIZ UDPMincho Medium
+- Meiryo
+- Meiryo UI
+- MS Mincho
+- MS PMincho
+- UD Digi Kyokasho N-B
+- UD Digi Kyokasho NK-B
+- UD Digi Kyokasho NK-R
+- UD Digi Kyokasho NP-B
+- UD Digi Kyokasho NP-R
+- UD Digi Kyokasho N-R
+- Yu Mincho
+
+### Kannada Supplemental Fonts
+
+- Tunga
+
+### Khmer Supplemental Fonts
+
+- DaunPenh
+- Khmer UI
+- MoolBoran
+
+### Korean Supplemental Fonts
+
+- Batang
+- BatangChe
+- Dotum
+- DotumChe
+- Gulim
+- GulimChe
+- Gungsuh
+- GungsuhChe
+
+### Lao Supplemental Fonts
+
+- DokChampa
+- Lao UI
+
+### Malayalam Supplemental Fonts
+
+- Kartika
+
+### Odia Supplemental Fonts
+
+- Kalinga
+
+### Pan-European Supplemental Fonts
+
+- Arial Nova
+- Arial Nova Cond
+- Georgia Pro
+- Georgia Pro Cond
+- Gill Sans Nova
+- Gill Sans Nova Cond
+- Neue Haas Grotesk Text Pro
+- Rockwell Nova
+- Rockwell Nova Cond
+- Verdana Pro
+- Verdana Pro Cond
+
+### Sinhala Supplemental Fonts
+
+- Iskoola Pota
+
+### Syriac Supplemental Fonts
+
+- Estrangelo Edessa
+
+### Tamil Supplemental Fonts
+
+- Latha
+- Vijaya
+
+### Telugu Supplemental Fonts
+
+- Gautami
+- Vani
+
+### Thai Supplemental Fonts
+
+- Angsana New
+- AngsanaUPC
+- Browallia New
+- BrowalliaUPC
+- Cordia New
+- CordiaUPC
+- DilleniaUPC
+- EucrosiaUPC
+- FreesiaUPC
+- IrisUPC
+- JasmineUPC
+- KodchiangUPC
+- Leelawadee
+- LilyUPC
+
+</details>
+
+## What else is new in Fontist 3.0
+
+Windows FOD support is part of the Fontist 3.0 release, which also includes
+these improvements:
+
+**Formula v5 schema.**
+Formulas now support multiple font formats (TTF, OTF, WOFF2), variable font
+metadata, and import provenance. See our earlier post on Formula v5 for the full details.
+
+**Platform-aware font selection.**
+Manifests now validate operating system compatibility before attempting to
+install platform-specific fonts, preventing errors when a font is only
+available on one platform.
+
+**Skip license prompts for already-installed fonts.**
+If a font is already present on the current operating system, Fontist skips the
+license confirmation step, reducing friction when re-running installations.
+
+**Lazy formulas initialization.**
+The formulas repository is no longer cloned at startup. Fontist defers this
+until the first operation that actually needs formulas, making initial startup
+faster.
+
+**Index rebuild speedup.**
+The index rebuild process has been optimized for large formula repositories,
+reducing the time needed to refresh the font index.
+
+## Conclusion
+
+Windows FOD font support rounds out Fontist's platform coverage. Together with
+macOS supplementary fonts, Google Fonts, SIL fonts, and Microsoft Office fonts,
+Fontist now provides automated installation of openly-licensed fonts across all
+major platforms.
+
+Install Fontist and try it:
+
+```sh
+$ gem install fontist
+$ fontist install "Meiryo"
+```

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,39 @@
+import { defineCollection, z } from 'astro:content'
+
+const blog = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    description: z.string().optional(),
+    date: z.union([z.string(), z.number(), z.date()]).transform(v =>
+      v instanceof Date ? v.toISOString().slice(0, 10) : String(v)
+    ),
+    authors: z.array(z.string()).optional(),
+  }),
+})
+
+const guide = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    description: z.string().optional(),
+  }),
+})
+
+const pages = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    description: z.string().optional(),
+  }),
+})
+
+const licenses = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    description: z.string().optional(),
+  }),
+})
+
+export const collections = { blog, guide, pages, licenses }

--- a/src/content/guide/choosing-formula.mdx
+++ b/src/content/guide/choosing-formula.mdx
@@ -1,0 +1,137 @@
+---
+title: Choosing a Formula
+description: How to choose the right Fontist formula for your needs
+---
+
+# Choosing a Formula
+
+With hundreds of formulas available, choosing the right one can be challenging. This guide helps you find the perfect formula for your use case.
+
+## By Use Case
+
+### Desktop Publishing
+
+For print design, desktop publishing, or local document creation:
+
+| Need | Recommended Formulas | Why |
+|------|---------------------|-----|
+| Professional typography | `tex_gyre`, `dejavu`, `liberation` | High quality, comprehensive character sets |
+| Open source | `google/*` formulas | OFL licensed, free to use |
+| Specific styles | Check formula for available weights | Look for "styles" section |
+
+### Web Development
+
+For self-hosted web fonts:
+
+| Need | Recommended Formulas | Why |
+|------|---------------------|-----|
+| WOFF/WOFF2 conversion | OFL-licensed formulas | Allow format conversion |
+| Subsetting | OFL, Apache, MIT licenses | Permit subsetting |
+| CDN hosting | Check license allows "Web (Hosting)" | Not all licenses allow this |
+
+### Document Generation (CI/CD)
+
+For automated document generation in pipelines:
+
+| Need | Recommended Formulas | Why |
+|------|---------------------|-----|
+| Reproducible builds | Open source formulas | Stable, well-defined licenses |
+| GitHub Actions | Any formula with clear license | Install via `fontist/setup-fontist` action |
+| Docker containers | Open source, freely distributable | Include in container images |
+
+## By License Type
+
+### Open Source (Recommended)
+
+::: tip Best for most use cases
+Open source licenses provide the most flexibility for all use cases.
+:::
+
+| License | Formulas | Use Cases |
+|---------|----------|-----------|
+| OFL 1.1 | `google/*`, `sil/*` | Any use case |
+| Apache 2.0 | Material fonts | Any use case |
+| MIT | Various | Any use case |
+
+### Platform Restricted
+
+::: warning License compliance required
+These fonts are only legal on specific platforms.
+:::
+
+| License | Platform | Cloud Options |
+|---------|----------|---------------|
+| Apple-only | macOS | GitHub Actions (macOS), MacStadium |
+| Microsoft Software | Windows | Azure, Windows containers |
+
+### Bundled Software
+
+These fonts require the parent software to be installed:
+
+| License | Requires | Usage Rights |
+|---------|----------|--------------|
+| Adobe Software | Adobe product installed | Use anywhere on that machine |
+| Microsoft Office | MS Office installed | Use anywhere on that machine |
+
+## Search Tips
+
+### Search by Font Name
+
+```bash
+fontist search "Open Sans"
+```
+
+### Search by Style
+
+```bash
+fontist search "Bold"
+```
+
+### Browse All
+
+```bash
+fontist list
+```
+
+## Common Scenarios
+
+### "I need a font for PDF generation"
+
+1. Check if you need specific branding/fonts
+2. If not, use OFL-licensed fonts like `google/roboto`, `google/opensans`
+3. Install: `fontist install "google/roboto"`
+
+### "I need to use macOS fonts in CI"
+
+1. Use GitHub Actions with `macos-latest` runner
+2. Fonts are pre-installed on macOS runners
+3. Or install via Fontist formula for reproducibility
+
+### "I need Microsoft fonts"
+
+**Option A: Microsoft Web Fonts (Freely Distributable)**
+- Core fonts like Arial, Times New Roman, Verdana
+- Install: `fontist install "andale"`
+- License allows redistribution
+
+**Option B: Microsoft Office Fonts**
+- Requires Microsoft Office license
+- Install on Windows machines/VMs
+
+## Decision Matrix
+
+| Your Need | License Priority | Platform |
+|-----------|-----------------|----------|
+| Any use, maximum freedom | OFL, Apache, MIT | Any |
+| Need specific font, flexible use | Check license | Any |
+| Need specific font, restricted license | Check platform | macOS/Windows |
+| Commercial product bundling | OFL, Apache, MIT | Any |
+| Server-side rendering | OFL, Apache, MIT, Free | Any |
+
+## Getting Help
+
+If you're still unsure:
+
+1. Check the formula page for license details
+2. Visit the font's homepage (linked in formula)
+3. Ask on [GitHub Discussions](https://github.com/fontist/formulas/discussions)

--- a/src/content/guide/choosing-formula.mdx.bak
+++ b/src/content/guide/choosing-formula.mdx.bak
@@ -1,0 +1,137 @@
+---
+title: Choosing a Formula
+description: How to choose the right Fontist formula for your needs
+---
+
+# Choosing a Formula
+
+With hundreds of formulas available, choosing the right one can be challenging. This guide helps you find the perfect formula for your use case.
+
+## By Use Case
+
+### Desktop Publishing
+
+For print design, desktop publishing, or local document creation:
+
+| Need | Recommended Formulas | Why |
+|------|---------------------|-----|
+| Professional typography | `tex_gyre`, `dejavu`, `liberation` | High quality, comprehensive character sets |
+| Open source | `google/*` formulas | OFL licensed, free to use |
+| Specific styles | Check formula for available weights | Look for "styles" section |
+
+### Web Development
+
+For self-hosted web fonts:
+
+| Need | Recommended Formulas | Why |
+|------|---------------------|-----|
+| WOFF/WOFF2 conversion | OFL-licensed formulas | Allow format conversion |
+| Subsetting | OFL, Apache, MIT licenses | Permit subsetting |
+| CDN hosting | Check license allows "Web (Hosting)" | Not all licenses allow this |
+
+### Document Generation (CI/CD)
+
+For automated document generation in pipelines:
+
+| Need | Recommended Formulas | Why |
+|------|---------------------|-----|
+| Reproducible builds | Open source formulas | Stable, well-defined licenses |
+| GitHub Actions | Any formula with clear license | Install via `fontist/setup-fontist` action |
+| Docker containers | Open source, freely distributable | Include in container images |
+
+## By License Type
+
+### Open Source (Recommended)
+
+::: tip Best for most use cases
+Open source licenses provide the most flexibility for all use cases.
+:::
+
+| License | Formulas | Use Cases |
+|---------|----------|-----------|
+| OFL 1.1 | `google/*`, `sil/*` | Any use case |
+| Apache 2.0 | Material fonts | Any use case |
+| MIT | Various | Any use case |
+
+### Platform Restricted
+
+::: warning License compliance required
+These fonts are only legal on specific platforms.
+:::
+
+| License | Platform | Cloud Options |
+|---------|----------|---------------|
+| Apple-only | macOS | GitHub Actions (macOS), MacStadium |
+| Microsoft Software | Windows | Azure, Windows containers |
+
+### Bundled Software
+
+These fonts require the parent software to be installed:
+
+| License | Requires | Usage Rights |
+|---------|----------|--------------|
+| Adobe Software | Adobe product installed | Use anywhere on that machine |
+| Microsoft Office | MS Office installed | Use anywhere on that machine |
+
+## Search Tips
+
+### Search by Font Name
+
+```bash
+fontist search "Open Sans"
+```
+
+### Search by Style
+
+```bash
+fontist search "Bold"
+```
+
+### Browse All
+
+```bash
+fontist list
+```
+
+## Common Scenarios
+
+### "I need a font for PDF generation"
+
+1. Check if you need specific branding/fonts
+2. If not, use OFL-licensed fonts like `google/roboto`, `google/opensans`
+3. Install: `fontist install "google/roboto"`
+
+### "I need to use macOS fonts in CI"
+
+1. Use GitHub Actions with `macos-latest` runner
+2. Fonts are pre-installed on macOS runners
+3. Or install via Fontist formula for reproducibility
+
+### "I need Microsoft fonts"
+
+**Option A: Microsoft Web Fonts (Freely Distributable)**
+- Core fonts like Arial, Times New Roman, Verdana
+- Install: `fontist install "andale"`
+- License allows redistribution
+
+**Option B: Microsoft Office Fonts**
+- Requires Microsoft Office license
+- Install on Windows machines/VMs
+
+## Decision Matrix
+
+| Your Need | License Priority | Platform |
+|-----------|-----------------|----------|
+| Any use, maximum freedom | OFL, Apache, MIT | Any |
+| Need specific font, flexible use | Check license | Any |
+| Need specific font, restricted license | Check platform | macOS/Windows |
+| Commercial product bundling | OFL, Apache, MIT | Any |
+| Server-side rendering | OFL, Apache, MIT, Free | Any |
+
+## Getting Help
+
+If you're still unsure:
+
+1. Check the formula page for license details
+2. Visit the font's homepage (linked in formula)
+3. Ask on [GitHub Discussions](https://github.com/fontist/formulas/discussions)

--- a/src/content/guide/create-formula.mdx
+++ b/src/content/guide/create-formula.mdx
@@ -1,0 +1,24 @@
+---
+title: "Create a Formula"
+search: false
+---
+
+# Create a Formula
+
+The purpose of a formula is to allow Fontist to determine where to download fonts.
+
+There is a command that can generate a formula by an archive's link:
+
+```sh
+fontist create-formula https://quoteunquoteapps.com/courierprime/downloads/courier-prime.zip
+```
+
+The result of its execution would be a YAML file. It can be changed with a text editor.
+
+You may need to change it manually when:
+
+- the script could not detect proper license text
+- you would like to change a name of a formula (may use the `--name` option)
+- the archive is private (see [private-formula-authentication](/formulas/guide/private-repositories#private-formula-authentication))
+
+The formula can be proposed to be merged to [the main repository](https://github.com/fontist/formulas), or added to a private repository.

--- a/src/content/guide/create-formula.mdx.bak
+++ b/src/content/guide/create-formula.mdx.bak
@@ -1,0 +1,23 @@
+---
+search: false
+---
+
+# Create a Formula
+
+The purpose of a formula is to allow Fontist to determine where to download fonts.
+
+There is a command that can generate a formula by an archive's link:
+
+```sh
+fontist create-formula https://quoteunquoteapps.com/courierprime/downloads/courier-prime.zip
+```
+
+The result of its execution would be a YAML file. It can be changed with a text editor.
+
+You may need to change it manually when:
+
+- the script could not detect proper license text
+- you would like to change a name of a formula (may use the `--name` option)
+- the archive is private (see [private-formula-authentication](/formulas/guide/private-repositories#private-formula-authentication))
+
+The formula can be proposed to be merged to [the main repository](https://github.com/fontist/formulas), or added to a private repository.

--- a/src/content/guide/formula-structure.mdx
+++ b/src/content/guide/formula-structure.mdx
@@ -1,0 +1,197 @@
+---
+title: Formula Structure
+description: Understanding the YAML structure of Fontist formulas
+---
+
+# Formula Structure
+
+A Fontist formula is a YAML file that describes how to download, extract, and install a font package. Understanding the structure helps you choose the right formula and troubleshoot issues.
+
+## Basic Structure
+
+```yaml
+---
+name: "Font Name"
+description: "Brief description of the font"
+homepage: "https://example.com/font"
+license_url: "https://example.com/license"
+
+resources:
+  font-archive.zip:
+    urls:
+      - https://example.com/download/font.zip
+    sha256: "abc123..."
+    file_size: 123456
+
+fonts:
+  - name: "Font Family"
+    styles:
+      - family_name: "Font Family"
+        type: "Regular"
+        full_name: "Font Family Regular"
+        post_script_name: "FontFamily-Regular"
+        version: "1.0"
+        font: "Font-Regular.ttf"
+        copyright: "Copyright holder"
+```
+
+## Key Fields
+
+### Metadata Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Display name of the font package |
+| `description` | No | Brief description |
+| `homepage` | No | URL to font homepage |
+| `license_url` | No | URL to license information |
+| `copyright` | No | Copyright notice |
+| `license` | No | License identifier |
+
+### Resources Section
+
+The `resources` section defines where to download font files:
+
+```yaml
+resources:
+  filename.zip:
+    urls:           # List of download URLs (mirrors)
+      - https://url1/font.zip
+      - https://url2/font.zip
+    sha256: "..."    # SHA256 checksum for verification
+    file_size: 12345 # File size in bytes
+```
+
+### Fonts Section
+
+The `fonts` section lists all font families and their styles:
+
+```yaml
+fonts:
+  - name: "Family Name"
+    styles:
+      - family_name: "Family Name"
+        type: "Regular"           # Style: Regular, Bold, Italic, etc.
+        full_name: "Family Name Regular"
+        post_script_name: "FamilyName-Regular"
+        version: "1.0"
+        font: "filename.ttf"      # Actual font file name
+        copyright: "..."
+```
+
+### Font Collections (TTC)
+
+For TrueType Collection files containing multiple fonts:
+
+```yaml
+font_collections:
+  - filename: "fonts.ttc"
+    fonts:
+      - name: "Font One"
+        styles:
+          - family_name: "Font One"
+            type: "Regular"
+            font: "FontOne-Regular"
+      - name: "Font Two"
+        styles:
+          - family_name: "Font Two"
+            type: "Regular"
+            font: "FontTwo-Regular"
+```
+
+## License Information
+
+### Open License
+
+For fonts with open source licenses:
+
+```yaml
+open_license: |
+  Full license text here...
+  SIL Open Font License 1.1
+  ...
+```
+
+### Requires License Agreement
+
+For fonts that require accepting a EULA:
+
+```yaml
+requires_license_agreement: |
+  END-USER LICENSE AGREEMENT
+  By using this software...
+```
+
+## Platform-Specific Formulas
+
+Some formulas are platform-specific:
+
+```yaml
+# macOS system fonts
+platforms:
+  - macos
+
+# Windows system fonts
+platforms:
+  - windows
+```
+
+## Extract Options
+
+For archives that need special extraction:
+
+```yaml
+extract:
+  format: cab        # For CAB files (Windows)
+  format: zip        # For ZIP files
+  format: gzip       # For GZIP files
+```
+
+## Example: Complete Formula
+
+```yaml
+---
+name: "Open Sans"
+description: "Open Sans is a humanist sans-serif typeface"
+homepage: "https://fonts.google.com/specimen/Open+Sans"
+license_url: "https://scripts.sil.org/OFL"
+
+resources:
+  open_sans.zip:
+    urls:
+      - https://github.com/googlefonts/OpenSans/archive/refs/tags/v1.0.zip
+    sha256: "abc123def456..."
+    file_size: 1234567
+
+fonts:
+  - name: "Open Sans"
+    styles:
+      - family_name: "Open Sans"
+        type: "Regular"
+        full_name: "Open Sans Regular"
+        post_script_name: "OpenSans-Regular"
+        version: "1.0"
+        font: "OpenSans-Regular.ttf"
+        copyright: "Google LLC"
+  - name: "Open Sans"
+    styles:
+      - family_name: "Open Sans"
+        type: "Bold"
+        full_name: "Open Sans Bold"
+        post_script_name: "OpenSans-Bold"
+        version: "1.0"
+        font: "OpenSans-Bold.ttf"
+        copyright: "Google LLC"
+
+open_license: |
+  Copyright 2020 The Open Sans Project Authors
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  ...
+```
+
+## See Also
+
+- [What is a Formula?](/formulas/guide/what-is-formula)
+- [Choosing a Formula](/formulas/guide/choosing-formula)
+- [Create a Formula](/formulas/guide/create-formula)

--- a/src/content/guide/formula-structure.mdx.bak
+++ b/src/content/guide/formula-structure.mdx.bak
@@ -1,0 +1,197 @@
+---
+title: Formula Structure
+description: Understanding the YAML structure of Fontist formulas
+---
+
+# Formula Structure
+
+A Fontist formula is a YAML file that describes how to download, extract, and install a font package. Understanding the structure helps you choose the right formula and troubleshoot issues.
+
+## Basic Structure
+
+```yaml
+---
+name: "Font Name"
+description: "Brief description of the font"
+homepage: "https://example.com/font"
+license_url: "https://example.com/license"
+
+resources:
+  font-archive.zip:
+    urls:
+      - https://example.com/download/font.zip
+    sha256: "abc123..."
+    file_size: 123456
+
+fonts:
+  - name: "Font Family"
+    styles:
+      - family_name: "Font Family"
+        type: "Regular"
+        full_name: "Font Family Regular"
+        post_script_name: "FontFamily-Regular"
+        version: "1.0"
+        font: "Font-Regular.ttf"
+        copyright: "Copyright holder"
+```
+
+## Key Fields
+
+### Metadata Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Display name of the font package |
+| `description` | No | Brief description |
+| `homepage` | No | URL to font homepage |
+| `license_url` | No | URL to license information |
+| `copyright` | No | Copyright notice |
+| `license` | No | License identifier |
+
+### Resources Section
+
+The `resources` section defines where to download font files:
+
+```yaml
+resources:
+  filename.zip:
+    urls:           # List of download URLs (mirrors)
+      - https://url1/font.zip
+      - https://url2/font.zip
+    sha256: "..."    # SHA256 checksum for verification
+    file_size: 12345 # File size in bytes
+```
+
+### Fonts Section
+
+The `fonts` section lists all font families and their styles:
+
+```yaml
+fonts:
+  - name: "Family Name"
+    styles:
+      - family_name: "Family Name"
+        type: "Regular"           # Style: Regular, Bold, Italic, etc.
+        full_name: "Family Name Regular"
+        post_script_name: "FamilyName-Regular"
+        version: "1.0"
+        font: "filename.ttf"      # Actual font file name
+        copyright: "..."
+```
+
+### Font Collections (TTC)
+
+For TrueType Collection files containing multiple fonts:
+
+```yaml
+font_collections:
+  - filename: "fonts.ttc"
+    fonts:
+      - name: "Font One"
+        styles:
+          - family_name: "Font One"
+            type: "Regular"
+            font: "FontOne-Regular"
+      - name: "Font Two"
+        styles:
+          - family_name: "Font Two"
+            type: "Regular"
+            font: "FontTwo-Regular"
+```
+
+## License Information
+
+### Open License
+
+For fonts with open source licenses:
+
+```yaml
+open_license: |
+  Full license text here...
+  SIL Open Font License 1.1
+  ...
+```
+
+### Requires License Agreement
+
+For fonts that require accepting a EULA:
+
+```yaml
+requires_license_agreement: |
+  END-USER LICENSE AGREEMENT
+  By using this software...
+```
+
+## Platform-Specific Formulas
+
+Some formulas are platform-specific:
+
+```yaml
+# macOS system fonts
+platforms:
+  - macos
+
+# Windows system fonts
+platforms:
+  - windows
+```
+
+## Extract Options
+
+For archives that need special extraction:
+
+```yaml
+extract:
+  format: cab        # For CAB files (Windows)
+  format: zip        # For ZIP files
+  format: gzip       # For GZIP files
+```
+
+## Example: Complete Formula
+
+```yaml
+---
+name: "Open Sans"
+description: "Open Sans is a humanist sans-serif typeface"
+homepage: "https://fonts.google.com/specimen/Open+Sans"
+license_url: "https://scripts.sil.org/OFL"
+
+resources:
+  open_sans.zip:
+    urls:
+      - https://github.com/googlefonts/OpenSans/archive/refs/tags/v1.0.zip
+    sha256: "abc123def456..."
+    file_size: 1234567
+
+fonts:
+  - name: "Open Sans"
+    styles:
+      - family_name: "Open Sans"
+        type: "Regular"
+        full_name: "Open Sans Regular"
+        post_script_name: "OpenSans-Regular"
+        version: "1.0"
+        font: "OpenSans-Regular.ttf"
+        copyright: "Google LLC"
+  - name: "Open Sans"
+    styles:
+      - family_name: "Open Sans"
+        type: "Bold"
+        full_name: "Open Sans Bold"
+        post_script_name: "OpenSans-Bold"
+        version: "1.0"
+        font: "OpenSans-Bold.ttf"
+        copyright: "Google LLC"
+
+open_license: |
+  Copyright 2020 The Open Sans Project Authors
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  ...
+```
+
+## See Also
+
+- [What is a Formula?](/formulas/guide/what-is-formula)
+- [Choosing a Formula](/formulas/guide/choosing-formula)
+- [Create a Formula](/formulas/guide/create-formula)

--- a/src/content/guide/private-repositories.mdx
+++ b/src/content/guide/private-repositories.mdx
@@ -1,0 +1,79 @@
+---
+title: "Private repositories"
+search: false
+---
+
+# Private repositories
+
+Fontist supports additional formulas repositories, called "private".
+
+## Create a private repository
+
+To create a new private repository, set up a new git repository, and place formulas there:
+
+```sh
+mkdir acme
+cd acme
+git init
+cp ../courier_prime.yml . # from example above
+git add courier_prime.yml
+git commit -m "Add formula for Courier Prime"
+git remote add origin git@example.com:acme/formulas.git # use your git hosting
+git push origin main -u
+```
+
+## Add a private repository to Fontist
+
+In order to find the private repository, fontist should be called with its URL or path:
+
+```sh
+fontist repo setup NAME URL
+```
+
+E.g.
+
+```sh
+fontist repo setup acme https://example.com/acme/formulas.git
+# or
+fontist repo setup acme git@example.com:acme/formulas.git
+```
+
+Then fonts from this repo can be installed:
+
+```sh
+fontist install "courier prime"
+```
+
+**NOTE:** A repository can be either an HTTPS or SSH Git repo. In case of SSH, a corresponding SSH key should be set up with `ssh-agent` in order to access this private repository.
+
+## Update a private repository
+
+If the private Fontist formula repository is updated, you can fetch the updates with the `repo update` command:
+
+```sh
+fontist repo update acme
+```
+
+If there is a need to avoid using private formulas, the repo can be removed with:
+
+```sh
+fontist repo remove acme
+```
+
+### Authentication for private formulas or private formula repositories
+
+Authorization of private archives in private formulas can be implemented with headers.
+
+Here is an example which works with Github releases:
+
+```yaml
+resources:
+  fonts.zip:
+    urls:
+      - url: https://example.com/repos/acme/formulas/releases/assets/38777461
+        headers:
+          Accept: application/octet-stream
+          Authorization: token ghp_1234567890abcdefghi
+```
+
+A token can be obtained on the [GitHub Settings > Tokens page](https://github.com/settings/tokens). This token should have at least the `repo` scope for access to these assets.

--- a/src/content/guide/private-repositories.mdx.bak
+++ b/src/content/guide/private-repositories.mdx.bak
@@ -1,0 +1,78 @@
+---
+search: false
+---
+
+# Private repositories
+
+Fontist supports additional formulas repositories, called "private".
+
+## Create a private repository
+
+To create a new private repository, set up a new git repository, and place formulas there:
+
+```sh
+mkdir acme
+cd acme
+git init
+cp ../courier_prime.yml . # from example above
+git add courier_prime.yml
+git commit -m "Add formula for Courier Prime"
+git remote add origin git@example.com:acme/formulas.git # use your git hosting
+git push origin main -u
+```
+
+## Add a private repository to Fontist
+
+In order to find the private repository, fontist should be called with its URL or path:
+
+```sh
+fontist repo setup NAME URL
+```
+
+E.g.
+
+```sh
+fontist repo setup acme https://example.com/acme/formulas.git
+# or
+fontist repo setup acme git@example.com:acme/formulas.git
+```
+
+Then fonts from this repo can be installed:
+
+```sh
+fontist install "courier prime"
+```
+
+**NOTE:** A repository can be either an HTTPS or SSH Git repo. In case of SSH, a corresponding SSH key should be set up with `ssh-agent` in order to access this private repository.
+
+## Update a private repository
+
+If the private Fontist formula repository is updated, you can fetch the updates with the `repo update` command:
+
+```sh
+fontist repo update acme
+```
+
+If there is a need to avoid using private formulas, the repo can be removed with:
+
+```sh
+fontist repo remove acme
+```
+
+### Authentication for private formulas or private formula repositories
+
+Authorization of private archives in private formulas can be implemented with headers.
+
+Here is an example which works with Github releases:
+
+```yaml
+resources:
+  fonts.zip:
+    urls:
+      - url: https://example.com/repos/acme/formulas/releases/assets/38777461
+        headers:
+          Accept: application/octet-stream
+          Authorization: token ghp_1234567890abcdefghi
+```
+
+A token can be obtained on the [GitHub Settings > Tokens page](https://github.com/settings/tokens). This token should have at least the `repo` scope for access to these assets.

--- a/src/content/guide/use-cases/cloud-vms.mdx
+++ b/src/content/guide/use-cases/cloud-vms.mdx
@@ -1,0 +1,158 @@
+---
+title: Cloud VMs
+description: Using Fontist formulas on cloud virtual machines
+---
+
+# Cloud VMs
+
+Fontist works on cloud VMs from AWS, Azure, GCP, and other providers.
+
+## Platform Considerations
+
+### Linux VMs
+
+Most cloud VMs run Linux - use open source or freely distributable fonts:
+
+```bash
+# SSH into VM
+gem install fontist
+fontist install "open_sans" "roboto"
+```
+
+### Windows VMs (Azure)
+
+Windows VMs on Azure can use Microsoft fonts:
+
+1. **Microsoft Office fonts** - If MS Office is installed
+2. **Microsoft Web Fonts** - Freely distributable (Andale, Arial, etc.)
+3. **Open source fonts** - Via Fontist
+
+### macOS VMs (MacStadium, GitHub Actions)
+
+macOS VMs can use Apple system fonts:
+
+- **Available**: All macOS system fonts
+- **Restriction**: Only on Apple-branded hardware
+- **GitHub Actions**: Available on `macos-latest` runners
+
+## AWS
+
+### EC2 User Data
+
+```bash
+#!/bin/bash
+# Install Ruby
+yum install -y ruby ruby-devel
+
+# Install Fontist
+gem install fontist
+
+# Install fonts
+fontist install "open_sans"
+```
+
+### ECS Task Definition
+
+```json
+{
+  "containerDefinitions": [{
+    "name": "app",
+    "image": "myapp:latest",
+    "command": ["fontist", "install", "open_sans"]
+  }]
+}
+```
+
+## Azure
+
+### VM Extension
+
+```json
+{
+  "type": "CustomScript",
+  "properties": {
+    "commandToExecute": "gem install fontist && fontist install open_sans"
+  }
+}
+```
+
+### Windows on Azure
+
+For Windows VMs with MS Office:
+
+```powershell
+# MS Office fonts are already available
+# Install additional fonts via Fontist
+gem install fontist
+fontist install "google/roboto"
+```
+
+## Google Cloud
+
+### Compute Engine Startup Script
+
+```bash
+#!/bin/bash
+apt-get update
+apt-get install -y ruby
+gem install fontist
+fontist install "open_sans"
+```
+
+### Cloud Run
+
+Fonts must be in the container image:
+
+```dockerfile
+FROM ruby:3.2-slim
+RUN gem install fontist
+RUN fontist install "open_sans"
+```
+
+## GitHub Hosted Runners
+
+### Ubuntu Runner
+
+```yaml
+runs-on: ubuntu-latest
+steps:
+  - run: gem install fontist
+  - run: fontist install "open_sans"
+```
+
+### macOS Runner
+
+```yaml
+runs-on: macos-latest
+steps:
+  # Apple fonts are pre-installed
+  - run: fontist install "open_sans"  # Additional fonts
+```
+
+### Windows Runner
+
+```yaml
+runs-on: windows-latest
+steps:
+  - run: gem install fontist
+  - run: fontist install "open_sans"
+```
+
+## License Compliance
+
+| Platform | Allowed Fonts |
+|----------|--------------|
+| Linux VMs | Open source, freely distributable |
+| Windows VMs (with Office) | MS Office fonts, open source |
+| macOS VMs | Apple fonts, open source |
+| GitHub Actions macOS | Apple fonts, open source |
+
+::: warning
+Apple-only fonts are only legal on Apple-branded hardware. GitHub Actions and MacStadium provide legitimate macOS VMs.
+:::
+
+## See Also
+
+- [CI/CD & Servers](/formulas/guide/use-cases/server-side)
+- [Docker & Containers](/formulas/guide/use-cases/containerized)
+- [Apple-only License](/formulas/licenses/apple-only)

--- a/src/content/guide/use-cases/cloud-vms.mdx.bak
+++ b/src/content/guide/use-cases/cloud-vms.mdx.bak
@@ -1,0 +1,158 @@
+---
+title: Cloud VMs
+description: Using Fontist formulas on cloud virtual machines
+---
+
+# Cloud VMs
+
+Fontist works on cloud VMs from AWS, Azure, GCP, and other providers.
+
+## Platform Considerations
+
+### Linux VMs
+
+Most cloud VMs run Linux - use open source or freely distributable fonts:
+
+```bash
+# SSH into VM
+gem install fontist
+fontist install "open_sans" "roboto"
+```
+
+### Windows VMs (Azure)
+
+Windows VMs on Azure can use Microsoft fonts:
+
+1. **Microsoft Office fonts** - If MS Office is installed
+2. **Microsoft Web Fonts** - Freely distributable (Andale, Arial, etc.)
+3. **Open source fonts** - Via Fontist
+
+### macOS VMs (MacStadium, GitHub Actions)
+
+macOS VMs can use Apple system fonts:
+
+- **Available**: All macOS system fonts
+- **Restriction**: Only on Apple-branded hardware
+- **GitHub Actions**: Available on `macos-latest` runners
+
+## AWS
+
+### EC2 User Data
+
+```bash
+#!/bin/bash
+# Install Ruby
+yum install -y ruby ruby-devel
+
+# Install Fontist
+gem install fontist
+
+# Install fonts
+fontist install "open_sans"
+```
+
+### ECS Task Definition
+
+```json
+{
+  "containerDefinitions": [{
+    "name": "app",
+    "image": "myapp:latest",
+    "command": ["fontist", "install", "open_sans"]
+  }]
+}
+```
+
+## Azure
+
+### VM Extension
+
+```json
+{
+  "type": "CustomScript",
+  "properties": {
+    "commandToExecute": "gem install fontist && fontist install open_sans"
+  }
+}
+```
+
+### Windows on Azure
+
+For Windows VMs with MS Office:
+
+```powershell
+# MS Office fonts are already available
+# Install additional fonts via Fontist
+gem install fontist
+fontist install "google/roboto"
+```
+
+## Google Cloud
+
+### Compute Engine Startup Script
+
+```bash
+#!/bin/bash
+apt-get update
+apt-get install -y ruby
+gem install fontist
+fontist install "open_sans"
+```
+
+### Cloud Run
+
+Fonts must be in the container image:
+
+```dockerfile
+FROM ruby:3.2-slim
+RUN gem install fontist
+RUN fontist install "open_sans"
+```
+
+## GitHub Hosted Runners
+
+### Ubuntu Runner
+
+```yaml
+runs-on: ubuntu-latest
+steps:
+  - run: gem install fontist
+  - run: fontist install "open_sans"
+```
+
+### macOS Runner
+
+```yaml
+runs-on: macos-latest
+steps:
+  # Apple fonts are pre-installed
+  - run: fontist install "open_sans"  # Additional fonts
+```
+
+### Windows Runner
+
+```yaml
+runs-on: windows-latest
+steps:
+  - run: gem install fontist
+  - run: fontist install "open_sans"
+```
+
+## License Compliance
+
+| Platform | Allowed Fonts |
+|----------|--------------|
+| Linux VMs | Open source, freely distributable |
+| Windows VMs (with Office) | MS Office fonts, open source |
+| macOS VMs | Apple fonts, open source |
+| GitHub Actions macOS | Apple fonts, open source |
+
+::: warning
+Apple-only fonts are only legal on Apple-branded hardware. GitHub Actions and MacStadium provide legitimate macOS VMs.
+:::
+
+## See Also
+
+- [CI/CD & Servers](/formulas/guide/use-cases/server-side)
+- [Docker & Containers](/formulas/guide/use-cases/containerized)
+- [Apple-only License](/formulas/licenses/apple-only)

--- a/src/content/guide/use-cases/containerized.mdx
+++ b/src/content/guide/use-cases/containerized.mdx
@@ -1,0 +1,179 @@
+---
+title: Docker & Containers
+description: Using Fontist formulas in Docker containers and Kubernetes
+---
+
+# Docker & Containers
+
+Fontist works well in containerized environments for reproducible font management.
+
+## Basic Docker Setup
+
+### Simple Dockerfile
+
+```dockerfile
+FROM ruby:3.2-slim
+
+# Install dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    fontconfig \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Fontist
+RUN gem install fontist
+
+# Install fonts
+RUN fontist install "open_sans" "roboto"
+
+# Your application
+COPY . /app
+WORKDIR /app
+CMD ["ruby", "app.rb"]
+```
+
+### With Fontfile
+
+Create a `Fontfile`:
+
+```
+"open_sans"
+"roboto"
+"source_sans_pro"
+```
+
+Dockerfile:
+
+```dockerfile
+FROM ruby:3.2-slim
+
+RUN gem install fontist
+COPY Fontfile .
+RUN xargs -a Fontfile fontist install
+
+COPY . /app
+WORKDIR /app
+CMD ["ruby", "app.rb"]
+```
+
+## Multi-stage Builds
+
+For smaller images:
+
+```dockerfile
+# Build stage - install fonts
+FROM ruby:3.2-slim AS builder
+
+RUN gem install fontist
+COPY Fontfile .
+RUN fontist install "open_sans"
+
+# Runtime stage - minimal image
+FROM debian:bookworm-slim
+
+# Copy only fonts, not Fontist
+COPY --from=builder /root/.fontist/fonts /usr/share/fonts/fontist
+
+# Refresh font cache
+RUN fc-cache -f -v
+
+CMD ["your-app"]
+```
+
+## Alpine Linux
+
+```dockerfile
+FROM ruby:3.2-alpine
+
+# Install dependencies
+RUN apk add --no-cache fontconfig freetype
+
+# Install Fontist
+RUN gem install fontist
+
+# Install fonts
+RUN fontist install "open_sans"
+
+CMD ["ruby", "app.rb"]
+```
+
+## Kubernetes
+
+### ConfigMap for Fonts
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: font-config
+data:
+  Fontfile: |
+    "open_sans"
+    "roboto"
+```
+
+### Init Container
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: install-fonts
+        image: ruby:3.2-slim
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            gem install fontist
+            fontist install "open_sans"
+        volumeMounts:
+        - name: fonts
+          mountPath: /root/.fontist
+      containers:
+      - name: app
+        image: myapp:latest
+        volumeMounts:
+        - name: fonts
+          mountPath: /root/.fontist
+      volumes:
+      - name: fonts
+        emptyDir: {}
+```
+
+## Docker Compose
+
+```yaml
+version: '3.8'
+services:
+  app:
+    build: .
+    volumes:
+      - fonts:/root/.fontist
+
+volumes:
+  fonts:
+```
+
+## Best Practices
+
+### 1. Use Specific Font Versions
+
+```bash
+fontist install "open_sans" --version "1.0"
+```
+
+### 2. Minimize Image Size
+
+- Use multi-stage builds
+- Only install needed fonts
+- Use `--no-install-recommends`
+
+### 3. Cache Fonts
+
+Mount `~/.fontist` as a volume to avoid reinstalling.
+
+## See Also
+
+- [CI/CD & Servers](/formulas/guide/use-cases/server-side)
+- [PDF Generation](/formulas/guide/use-cases/pdf-generation)

--- a/src/content/guide/use-cases/containerized.mdx.bak
+++ b/src/content/guide/use-cases/containerized.mdx.bak
@@ -1,0 +1,179 @@
+---
+title: Docker & Containers
+description: Using Fontist formulas in Docker containers and Kubernetes
+---
+
+# Docker & Containers
+
+Fontist works well in containerized environments for reproducible font management.
+
+## Basic Docker Setup
+
+### Simple Dockerfile
+
+```dockerfile
+FROM ruby:3.2-slim
+
+# Install dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    fontconfig \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Fontist
+RUN gem install fontist
+
+# Install fonts
+RUN fontist install "open_sans" "roboto"
+
+# Your application
+COPY . /app
+WORKDIR /app
+CMD ["ruby", "app.rb"]
+```
+
+### With Fontfile
+
+Create a `Fontfile`:
+
+```
+"open_sans"
+"roboto"
+"source_sans_pro"
+```
+
+Dockerfile:
+
+```dockerfile
+FROM ruby:3.2-slim
+
+RUN gem install fontist
+COPY Fontfile .
+RUN xargs -a Fontfile fontist install
+
+COPY . /app
+WORKDIR /app
+CMD ["ruby", "app.rb"]
+```
+
+## Multi-stage Builds
+
+For smaller images:
+
+```dockerfile
+# Build stage - install fonts
+FROM ruby:3.2-slim AS builder
+
+RUN gem install fontist
+COPY Fontfile .
+RUN fontist install "open_sans"
+
+# Runtime stage - minimal image
+FROM debian:bookworm-slim
+
+# Copy only fonts, not Fontist
+COPY --from=builder /root/.fontist/fonts /usr/share/fonts/fontist
+
+# Refresh font cache
+RUN fc-cache -f -v
+
+CMD ["your-app"]
+```
+
+## Alpine Linux
+
+```dockerfile
+FROM ruby:3.2-alpine
+
+# Install dependencies
+RUN apk add --no-cache fontconfig freetype
+
+# Install Fontist
+RUN gem install fontist
+
+# Install fonts
+RUN fontist install "open_sans"
+
+CMD ["ruby", "app.rb"]
+```
+
+## Kubernetes
+
+### ConfigMap for Fonts
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: font-config
+data:
+  Fontfile: |
+    "open_sans"
+    "roboto"
+```
+
+### Init Container
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: install-fonts
+        image: ruby:3.2-slim
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            gem install fontist
+            fontist install "open_sans"
+        volumeMounts:
+        - name: fonts
+          mountPath: /root/.fontist
+      containers:
+      - name: app
+        image: myapp:latest
+        volumeMounts:
+        - name: fonts
+          mountPath: /root/.fontist
+      volumes:
+      - name: fonts
+        emptyDir: {}
+```
+
+## Docker Compose
+
+```yaml
+version: '3.8'
+services:
+  app:
+    build: .
+    volumes:
+      - fonts:/root/.fontist
+
+volumes:
+  fonts:
+```
+
+## Best Practices
+
+### 1. Use Specific Font Versions
+
+```bash
+fontist install "open_sans" --version "1.0"
+```
+
+### 2. Minimize Image Size
+
+- Use multi-stage builds
+- Only install needed fonts
+- Use `--no-install-recommends`
+
+### 3. Cache Fonts
+
+Mount `~/.fontist` as a volume to avoid reinstalling.
+
+## See Also
+
+- [CI/CD & Servers](/formulas/guide/use-cases/server-side)
+- [PDF Generation](/formulas/guide/use-cases/pdf-generation)

--- a/src/content/guide/use-cases/desktop-publishing.mdx
+++ b/src/content/guide/use-cases/desktop-publishing.mdx
@@ -1,0 +1,89 @@
+---
+title: Desktop Publishing
+description: Using Fontist formulas for desktop publishing applications
+---
+
+# Desktop Publishing
+
+Fontist integrates seamlessly with desktop publishing applications like Adobe InDesign, Scribus, and Adobe Illustrator.
+
+## Installation
+
+### Install Fonts for Desktop Use
+
+```bash
+# Install a font for desktop use
+fontist install "open_sans"
+
+# Install multiple fonts
+fontist install "roboto" "lato" "source_sans"
+```
+
+### Verify Installation
+
+```bash
+# Check installed fonts
+fontist list
+
+# Find specific font location
+fontist status "Open Sans"
+```
+
+## Application Integration
+
+### Adobe InDesign
+
+1. **Install fonts** using Fontist
+2. **Restart InDesign** to detect new fonts
+3. **Use fonts** in your documents
+
+::: tip
+Fontist installs fonts to `~/.fontist/fonts/` by default. Some applications may need to be configured to use this directory.
+:::
+
+### Scribus
+
+Scribus automatically detects fonts installed in user directories:
+
+```bash
+# Install Scribus-compatible fonts
+fontist install "liberation" "dejavu"
+```
+
+### Adobe Illustrator
+
+Same as InDesign - install fonts and restart the application.
+
+## License Considerations
+
+For desktop publishing, pay attention to:
+
+| Use Case | License Required | Notes |
+|----------|-----------------|-------|
+| Print documents | Most licenses allow | Check "Commercial (Static)" permission |
+| PDF export | Most licenses allow | Embedding may have conditions |
+| Client work | Check license | Some restrict commercial work |
+| Font modification | Rarely allowed | OFL requires renaming |
+
+### Recommended Licenses for Desktop Publishing
+
+- **OFL 1.1** - Best choice, allows all desktop uses
+- **Apache 2.0** - Fully permissive
+- **MIT** - Fully permissive
+
+## Troubleshooting
+
+### Fonts Not Showing in Application
+
+1. Restart the application
+2. Check font installation: `fontist status "Font Name"`
+3. Some apps need system font cache refresh
+
+### Font Subsetting in PDFs
+
+Most licenses allow subsetting when embedding in PDFs. OFL 1.1 explicitly permits this.
+
+## See Also
+
+- [Choosing a Formula](/formulas/guide/choosing-formula)
+- [License Overview](/formulas/licenses/)

--- a/src/content/guide/use-cases/desktop-publishing.mdx.bak
+++ b/src/content/guide/use-cases/desktop-publishing.mdx.bak
@@ -1,0 +1,89 @@
+---
+title: Desktop Publishing
+description: Using Fontist formulas for desktop publishing applications
+---
+
+# Desktop Publishing
+
+Fontist integrates seamlessly with desktop publishing applications like Adobe InDesign, Scribus, and Adobe Illustrator.
+
+## Installation
+
+### Install Fonts for Desktop Use
+
+```bash
+# Install a font for desktop use
+fontist install "open_sans"
+
+# Install multiple fonts
+fontist install "roboto" "lato" "source_sans"
+```
+
+### Verify Installation
+
+```bash
+# Check installed fonts
+fontist list
+
+# Find specific font location
+fontist status "Open Sans"
+```
+
+## Application Integration
+
+### Adobe InDesign
+
+1. **Install fonts** using Fontist
+2. **Restart InDesign** to detect new fonts
+3. **Use fonts** in your documents
+
+::: tip
+Fontist installs fonts to `~/.fontist/fonts/` by default. Some applications may need to be configured to use this directory.
+:::
+
+### Scribus
+
+Scribus automatically detects fonts installed in user directories:
+
+```bash
+# Install Scribus-compatible fonts
+fontist install "liberation" "dejavu"
+```
+
+### Adobe Illustrator
+
+Same as InDesign - install fonts and restart the application.
+
+## License Considerations
+
+For desktop publishing, pay attention to:
+
+| Use Case | License Required | Notes |
+|----------|-----------------|-------|
+| Print documents | Most licenses allow | Check "Commercial (Static)" permission |
+| PDF export | Most licenses allow | Embedding may have conditions |
+| Client work | Check license | Some restrict commercial work |
+| Font modification | Rarely allowed | OFL requires renaming |
+
+### Recommended Licenses for Desktop Publishing
+
+- **OFL 1.1** - Best choice, allows all desktop uses
+- **Apache 2.0** - Fully permissive
+- **MIT** - Fully permissive
+
+## Troubleshooting
+
+### Fonts Not Showing in Application
+
+1. Restart the application
+2. Check font installation: `fontist status "Font Name"`
+3. Some apps need system font cache refresh
+
+### Font Subsetting in PDFs
+
+Most licenses allow subsetting when embedding in PDFs. OFL 1.1 explicitly permits this.
+
+## See Also
+
+- [Choosing a Formula](/formulas/guide/choosing-formula)
+- [License Overview](/formulas/licenses/)

--- a/src/content/guide/use-cases/document-generation.mdx
+++ b/src/content/guide/use-cases/document-generation.mdx
@@ -1,0 +1,122 @@
+---
+title: Document Generation
+description: Using Fontist formulas for automated document generation
+---
+
+# Document Generation
+
+Fontist enables reproducible document generation with tools like Pandoc, Asciidoctor, and LaTeX.
+
+## Common Tools
+
+### Pandoc
+
+```bash
+# Install fonts for PDF generation
+fontist install "liberation" "dejavu"
+
+# Generate PDF with custom fonts
+pandoc document.md -o document.pdf \
+  --pdf-engine=xelatex \
+  -V mainfont="Liberation Serif"
+```
+
+### Asciidoctor PDF
+
+```ruby
+# theme.yml
+font:
+  catalog:
+    Roboto: /path/to/fontist/fonts/Roboto-Regular.ttf
+```
+
+```bash
+asciidoctor-pdf document.adoc -a pdf-theme=theme.yml
+```
+
+### LaTeX / XeLaTeX
+
+```latex
+\documentclass{article}
+\usepackage{fontspec}
+\setmainfont{Liberation Serif}
+```
+
+```bash
+# Install fonts first
+fontist install "liberation"
+
+# Compile with XeLaTeX
+xelatex document.tex
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+- name: Install Fontist
+  run: gem install fontist
+
+- name: Install fonts
+  run: fontist install "liberation" "dejavu"
+
+- name: Generate PDF
+  run: pandoc document.md -o document.pdf
+```
+
+### GitLab CI
+
+```yaml
+generate-docs:
+  script:
+    - gem install fontist
+    - fontist install "liberation"
+    - pandoc document.md -o document.pdf
+  artifacts:
+    paths:
+      - document.pdf
+```
+
+## Best Practices
+
+### 1. Use Open Source Fonts
+
+For CI/CD, prefer OFL-licensed fonts:
+
+```bash
+fontist install "google/roboto" "google/opensans"
+```
+
+### 2. Document Font Dependencies
+
+Create a `Fontfile`:
+
+```
+"roboto"
+"source_sans_pro"
+"dejavu"
+```
+
+Install all at once:
+
+```bash
+xargs -a Fontfile fontist install
+```
+
+### 3. Cache Font Installations
+
+In CI, cache `~/.fontist/` between runs.
+
+## License Considerations
+
+| Use Case | Check Permission |
+|----------|-----------------|
+| Server-side rendering | "Server/CI" |
+| PDF embedding | "Commercial (Static)" |
+| Document distribution | "Redistribution" |
+
+## See Also
+
+- [CI/CD & Servers](/formulas/guide/use-cases/server-side)
+- [PDF Generation](/formulas/guide/use-cases/pdf-generation)

--- a/src/content/guide/use-cases/document-generation.mdx.bak
+++ b/src/content/guide/use-cases/document-generation.mdx.bak
@@ -1,0 +1,122 @@
+---
+title: Document Generation
+description: Using Fontist formulas for automated document generation
+---
+
+# Document Generation
+
+Fontist enables reproducible document generation with tools like Pandoc, Asciidoctor, and LaTeX.
+
+## Common Tools
+
+### Pandoc
+
+```bash
+# Install fonts for PDF generation
+fontist install "liberation" "dejavu"
+
+# Generate PDF with custom fonts
+pandoc document.md -o document.pdf \
+  --pdf-engine=xelatex \
+  -V mainfont="Liberation Serif"
+```
+
+### Asciidoctor PDF
+
+```ruby
+# theme.yml
+font:
+  catalog:
+    Roboto: /path/to/fontist/fonts/Roboto-Regular.ttf
+```
+
+```bash
+asciidoctor-pdf document.adoc -a pdf-theme=theme.yml
+```
+
+### LaTeX / XeLaTeX
+
+```latex
+\documentclass{article}
+\usepackage{fontspec}
+\setmainfont{Liberation Serif}
+```
+
+```bash
+# Install fonts first
+fontist install "liberation"
+
+# Compile with XeLaTeX
+xelatex document.tex
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+- name: Install Fontist
+  run: gem install fontist
+
+- name: Install fonts
+  run: fontist install "liberation" "dejavu"
+
+- name: Generate PDF
+  run: pandoc document.md -o document.pdf
+```
+
+### GitLab CI
+
+```yaml
+generate-docs:
+  script:
+    - gem install fontist
+    - fontist install "liberation"
+    - pandoc document.md -o document.pdf
+  artifacts:
+    paths:
+      - document.pdf
+```
+
+## Best Practices
+
+### 1. Use Open Source Fonts
+
+For CI/CD, prefer OFL-licensed fonts:
+
+```bash
+fontist install "google/roboto" "google/opensans"
+```
+
+### 2. Document Font Dependencies
+
+Create a `Fontfile`:
+
+```
+"roboto"
+"source_sans_pro"
+"dejavu"
+```
+
+Install all at once:
+
+```bash
+xargs -a Fontfile fontist install
+```
+
+### 3. Cache Font Installations
+
+In CI, cache `~/.fontist/` between runs.
+
+## License Considerations
+
+| Use Case | Check Permission |
+|----------|-----------------|
+| Server-side rendering | "Server/CI" |
+| PDF embedding | "Commercial (Static)" |
+| Document distribution | "Redistribution" |
+
+## See Also
+
+- [CI/CD & Servers](/formulas/guide/use-cases/server-side)
+- [PDF Generation](/formulas/guide/use-cases/pdf-generation)

--- a/src/content/guide/use-cases/pdf-generation.mdx
+++ b/src/content/guide/use-cases/pdf-generation.mdx
@@ -1,0 +1,130 @@
+---
+title: PDF Generation
+description: Using Fontist formulas for PDF generation in various programming languages
+---
+
+# PDF Generation
+
+Fontist provides fonts for PDF generation in Ruby, Python, JavaScript, and other languages.
+
+## Ruby
+
+### Prawn
+
+```ruby
+require 'prawn'
+
+# Install fonts first: fontist install "dejavu"
+font_path = File.expand_path('~/.fontist/fonts/DejaVuSans.ttf')
+
+Prawn::Document.generate('document.pdf') do
+  font font_path
+  text "Hello, World!"
+end
+```
+
+### Grover (Headless Chrome)
+
+```ruby
+require 'grover'
+
+# Fonts available to the system will be used
+Grover.new('<h1>Hello</h1>').to_pdf
+```
+
+## Python
+
+### ReportLab
+
+```python
+from reportlab.pdfgen import canvas
+from reportlab.pdfbase import pdfmetrics
+from reportlab.pdfbase.ttfonts import TTFont
+
+# Install: fontist install "liberation"
+pdfmetrics.registerFont(TTFont('Liberation', '/home/user/.fontist/fonts/LiberationSerif-Regular.ttf'))
+
+c = canvas.Canvas('document.pdf')
+c.setFont('Liberation', 12)
+c.drawString(100, 750, "Hello, World!")
+c.save()
+```
+
+### WeasyPrint
+
+```python
+from weasyprint import HTML
+
+# CSS can reference installed fonts
+HTML(string='<p style="font-family: DejaVu Sans">Hello</p>').write_pdf('output.pdf')
+```
+
+## Node.js
+
+### PDFKit
+
+```javascript
+const PDFDocument = require('pdfkit');
+
+const doc = new PDFDocument();
+doc.font('/home/user/.fontist/fonts/DejaVuSans.ttf')
+   .text('Hello, World!')
+   .end();
+```
+
+### Puppeteer/Playwright
+
+```javascript
+const puppeteer = require('puppeteer');
+
+// Fonts installed via fontist are available
+const browser = await puppeteer.launch();
+const page = await browser.newPage();
+await page.setContent('<h1>Hello</h1>');
+await page.pdf({ path: 'output.pdf' });
+```
+
+## wkhtmltopdf
+
+```bash
+# Install fonts
+fontist install "liberation"
+
+# Generate PDF
+wkhtmltopdf --encoding utf-8 input.html output.pdf
+```
+
+## Prince XML
+
+```bash
+fontist install "dejavu"
+prince input.html -o output.pdf
+```
+
+## Best Practices
+
+### 1. Embed Fonts in PDF
+
+Always embed fonts for consistent rendering:
+
+```ruby
+# Prawn - fonts are embedded by default
+font '/path/to/font.ttf'
+```
+
+### 2. Use Unicode Fonts
+
+For international text, use fonts with broad character coverage:
+
+```bash
+fontist install "noto" "dejavu"
+```
+
+### 3. Check Embedding Permissions
+
+Most open source licenses allow embedding. Check the license page for details.
+
+## See Also
+
+- [Document Generation](/formulas/guide/use-cases/document-generation)
+- [CI/CD & Servers](/formulas/guide/use-cases/server-side)

--- a/src/content/guide/use-cases/pdf-generation.mdx.bak
+++ b/src/content/guide/use-cases/pdf-generation.mdx.bak
@@ -1,0 +1,130 @@
+---
+title: PDF Generation
+description: Using Fontist formulas for PDF generation in various programming languages
+---
+
+# PDF Generation
+
+Fontist provides fonts for PDF generation in Ruby, Python, JavaScript, and other languages.
+
+## Ruby
+
+### Prawn
+
+```ruby
+require 'prawn'
+
+# Install fonts first: fontist install "dejavu"
+font_path = File.expand_path('~/.fontist/fonts/DejaVuSans.ttf')
+
+Prawn::Document.generate('document.pdf') do
+  font font_path
+  text "Hello, World!"
+end
+```
+
+### Grover (Headless Chrome)
+
+```ruby
+require 'grover'
+
+# Fonts available to the system will be used
+Grover.new('<h1>Hello</h1>').to_pdf
+```
+
+## Python
+
+### ReportLab
+
+```python
+from reportlab.pdfgen import canvas
+from reportlab.pdfbase import pdfmetrics
+from reportlab.pdfbase.ttfonts import TTFont
+
+# Install: fontist install "liberation"
+pdfmetrics.registerFont(TTFont('Liberation', '/home/user/.fontist/fonts/LiberationSerif-Regular.ttf'))
+
+c = canvas.Canvas('document.pdf')
+c.setFont('Liberation', 12)
+c.drawString(100, 750, "Hello, World!")
+c.save()
+```
+
+### WeasyPrint
+
+```python
+from weasyprint import HTML
+
+# CSS can reference installed fonts
+HTML(string='<p style="font-family: DejaVu Sans">Hello</p>').write_pdf('output.pdf')
+```
+
+## Node.js
+
+### PDFKit
+
+```javascript
+const PDFDocument = require('pdfkit');
+
+const doc = new PDFDocument();
+doc.font('/home/user/.fontist/fonts/DejaVuSans.ttf')
+   .text('Hello, World!')
+   .end();
+```
+
+### Puppeteer/Playwright
+
+```javascript
+const puppeteer = require('puppeteer');
+
+// Fonts installed via fontist are available
+const browser = await puppeteer.launch();
+const page = await browser.newPage();
+await page.setContent('<h1>Hello</h1>');
+await page.pdf({ path: 'output.pdf' });
+```
+
+## wkhtmltopdf
+
+```bash
+# Install fonts
+fontist install "liberation"
+
+# Generate PDF
+wkhtmltopdf --encoding utf-8 input.html output.pdf
+```
+
+## Prince XML
+
+```bash
+fontist install "dejavu"
+prince input.html -o output.pdf
+```
+
+## Best Practices
+
+### 1. Embed Fonts in PDF
+
+Always embed fonts for consistent rendering:
+
+```ruby
+# Prawn - fonts are embedded by default
+font '/path/to/font.ttf'
+```
+
+### 2. Use Unicode Fonts
+
+For international text, use fonts with broad character coverage:
+
+```bash
+fontist install "noto" "dejavu"
+```
+
+### 3. Check Embedding Permissions
+
+Most open source licenses allow embedding. Check the license page for details.
+
+## See Also
+
+- [Document Generation](/formulas/guide/use-cases/document-generation)
+- [CI/CD & Servers](/formulas/guide/use-cases/server-side)

--- a/src/content/guide/use-cases/server-side.mdx
+++ b/src/content/guide/use-cases/server-side.mdx
@@ -1,0 +1,144 @@
+---
+title: CI/CD & Servers
+description: Using Fontist formulas in continuous integration and server environments
+---
+
+# CI/CD & Servers
+
+Fontist is designed for reproducible font installation in automated environments.
+
+## GitHub Actions
+
+### Official Action
+
+```yaml
+- name: Install fonts
+  uses: fontist/setup-fontist@v2
+  with:
+    fonts: Open Sans, Roboto, Source Sans Pro
+```
+
+### Manual Installation
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Install Fontist
+        run: gem install fontist
+
+      - name: Install fonts
+        run: fontist install "open_sans" "roboto"
+
+      - name: Generate documents
+        run: pandoc input.md -o output.pdf
+```
+
+### Caching
+
+```yaml
+- name: Cache fonts
+  uses: actions/cache@v4
+  with:
+    path: ~/.fontist
+    key: fonts-${{ hashFiles('Fontfile') }}
+```
+
+## GitLab CI
+
+```yaml
+generate-docs:
+  image: ruby:3.2
+  cache:
+    paths:
+      - ~/.fontist/
+  script:
+    - gem install fontist
+    - fontist install "open_sans"
+    - pandoc input.md -o output.pdf
+  artifacts:
+    paths:
+      - output.pdf
+```
+
+## Docker
+
+### Dockerfile
+
+```dockerfile
+FROM ruby:3.2
+
+# Install Fontist
+RUN gem install fontist
+
+# Install fonts during build
+RUN fontist install "open_sans" "roboto"
+
+# Or copy a Fontfile and install
+COPY Fontfile .
+RUN xargs -a Fontfile fontist install
+```
+
+### Multi-stage Build
+
+```dockerfile
+# Build stage
+FROM ruby:3.2 AS builder
+RUN gem install fontist
+COPY Fontfile .
+RUN xargs -a Fontfile fontist install
+
+# Runtime stage
+FROM debian:bookworm-slim
+COPY --from=builder /root/.fontist /root/.fontist
+```
+
+## Server Deployment
+
+### systemd Service
+
+```ini
+[Unit]
+Description=Document Generator
+
+[Service]
+ExecStartPre=/usr/bin/fontist install "open_sans"
+ExecStart=/usr/bin/ruby /app/server.rb
+```
+
+### Environment Variables
+
+```bash
+# Custom font directory
+export FONTIST_PATH=/var/lib/fonts
+fontist install "open_sans"
+```
+
+## License Considerations for Servers
+
+| License Type | Server Use | Notes |
+|--------------|------------|-------|
+| OFL 1.1 | ✅ Allowed | Best choice for CI/CD |
+| Apache/MIT | ✅ Allowed | Fully permissive |
+| Platform Restricted | ⚠️ Check | macOS fonts only on macOS runners |
+| Bundled Software | ❌ Usually no | Cannot extract from software |
+
+### Platform-Specific Runners
+
+- **macOS runners**: Can use Apple-only fonts
+- **Windows runners**: Can use Microsoft fonts
+- **Linux runners**: Use open source or freely distributable fonts
+
+## See Also
+
+- [Docker & Containers](/formulas/guide/use-cases/containerized)
+- [Cloud VMs](/formulas/guide/use-cases/cloud-vms)
+- [GitHub Actions Integration](https://github.com/fontist/setup-fontist)

--- a/src/content/guide/use-cases/server-side.mdx.bak
+++ b/src/content/guide/use-cases/server-side.mdx.bak
@@ -1,0 +1,144 @@
+---
+title: CI/CD & Servers
+description: Using Fontist formulas in continuous integration and server environments
+---
+
+# CI/CD & Servers
+
+Fontist is designed for reproducible font installation in automated environments.
+
+## GitHub Actions
+
+### Official Action
+
+```yaml
+- name: Install fonts
+  uses: fontist/setup-fontist@v2
+  with:
+    fonts: Open Sans, Roboto, Source Sans Pro
+```
+
+### Manual Installation
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Install Fontist
+        run: gem install fontist
+
+      - name: Install fonts
+        run: fontist install "open_sans" "roboto"
+
+      - name: Generate documents
+        run: pandoc input.md -o output.pdf
+```
+
+### Caching
+
+```yaml
+- name: Cache fonts
+  uses: actions/cache@v4
+  with:
+    path: ~/.fontist
+    key: fonts-${{ hashFiles('Fontfile') }}
+```
+
+## GitLab CI
+
+```yaml
+generate-docs:
+  image: ruby:3.2
+  cache:
+    paths:
+      - ~/.fontist/
+  script:
+    - gem install fontist
+    - fontist install "open_sans"
+    - pandoc input.md -o output.pdf
+  artifacts:
+    paths:
+      - output.pdf
+```
+
+## Docker
+
+### Dockerfile
+
+```dockerfile
+FROM ruby:3.2
+
+# Install Fontist
+RUN gem install fontist
+
+# Install fonts during build
+RUN fontist install "open_sans" "roboto"
+
+# Or copy a Fontfile and install
+COPY Fontfile .
+RUN xargs -a Fontfile fontist install
+```
+
+### Multi-stage Build
+
+```dockerfile
+# Build stage
+FROM ruby:3.2 AS builder
+RUN gem install fontist
+COPY Fontfile .
+RUN xargs -a Fontfile fontist install
+
+# Runtime stage
+FROM debian:bookworm-slim
+COPY --from=builder /root/.fontist /root/.fontist
+```
+
+## Server Deployment
+
+### systemd Service
+
+```ini
+[Unit]
+Description=Document Generator
+
+[Service]
+ExecStartPre=/usr/bin/fontist install "open_sans"
+ExecStart=/usr/bin/ruby /app/server.rb
+```
+
+### Environment Variables
+
+```bash
+# Custom font directory
+export FONTIST_PATH=/var/lib/fonts
+fontist install "open_sans"
+```
+
+## License Considerations for Servers
+
+| License Type | Server Use | Notes |
+|--------------|------------|-------|
+| OFL 1.1 | ✅ Allowed | Best choice for CI/CD |
+| Apache/MIT | ✅ Allowed | Fully permissive |
+| Platform Restricted | ⚠️ Check | macOS fonts only on macOS runners |
+| Bundled Software | ❌ Usually no | Cannot extract from software |
+
+### Platform-Specific Runners
+
+- **macOS runners**: Can use Apple-only fonts
+- **Windows runners**: Can use Microsoft fonts
+- **Linux runners**: Use open source or freely distributable fonts
+
+## See Also
+
+- [Docker & Containers](/formulas/guide/use-cases/containerized)
+- [Cloud VMs](/formulas/guide/use-cases/cloud-vms)
+- [GitHub Actions Integration](https://github.com/fontist/setup-fontist)

--- a/src/content/guide/use-cases/web-development.mdx
+++ b/src/content/guide/use-cases/web-development.mdx
@@ -1,0 +1,89 @@
+---
+title: Web Development
+description: Using Fontist formulas for web development and self-hosted web fonts
+---
+
+# Web Development
+
+Fontist helps you download and manage fonts for self-hosted web applications.
+
+## Self-Hosting Web Fonts
+
+### Download Fonts
+
+```bash
+# Install fonts for web use
+fontist install "roboto"
+```
+
+### Convert to Web Formats
+
+Most fonts can be converted to WOFF/WOFF2:
+
+```bash
+# Using fonttools
+pip install fonttools brotli
+pyftsubset Roboto-Regular.ttf \
+  --output-file=Roboto-Regular.woff2 \
+  --flavor=woff2
+```
+
+### CSS @font-face
+
+```css
+@font-face {
+  font-family: 'Roboto';
+  src: url('/fonts/Roboto-Regular.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+}
+```
+
+## License Considerations
+
+| Use Case | Permission to Check |
+|----------|-------------------|
+| Self-hosting | "Web (Hosting)" |
+| WOFF/WOFF2 conversion | "Format Conversion" |
+| Subsetting | "Web (Subsetting)" |
+| CDN delivery | Check redistribution terms |
+
+### Best Licenses for Web
+
+- **OFL 1.1** - Allows all web uses
+- **Apache 2.0** - Fully permissive
+- **CC0** - Public domain, no restrictions
+
+### Restricted Licenses
+
+- **Platform Restricted** (Apple-only) - Cannot use on web servers
+- **Bundled Software** - Cannot extract for web use
+
+## Subsetting for Performance
+
+```bash
+# Create Latin-only subset
+pyftsubset Roboto-Regular.ttf \
+  --output-file=Roboto-Regular-latin.woff2 \
+  --flavor=woff2 \
+  --subset-latin \
+  --layout-features='*'
+```
+
+## Google Fonts Alternative
+
+For web use, you can also use Google Fonts CDN:
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+```
+
+Use Fontist when you need to:
+- Self-host for privacy/performance
+- Use fonts not on Google Fonts
+- Ensure reproducible builds
+
+## See Also
+
+- [Choosing a Formula](/formulas/guide/choosing-formula)
+- [OFL License](/formulas/licenses/ofl)

--- a/src/content/guide/use-cases/web-development.mdx.bak
+++ b/src/content/guide/use-cases/web-development.mdx.bak
@@ -1,0 +1,89 @@
+---
+title: Web Development
+description: Using Fontist formulas for web development and self-hosted web fonts
+---
+
+# Web Development
+
+Fontist helps you download and manage fonts for self-hosted web applications.
+
+## Self-Hosting Web Fonts
+
+### Download Fonts
+
+```bash
+# Install fonts for web use
+fontist install "roboto"
+```
+
+### Convert to Web Formats
+
+Most fonts can be converted to WOFF/WOFF2:
+
+```bash
+# Using fonttools
+pip install fonttools brotli
+pyftsubset Roboto-Regular.ttf \
+  --output-file=Roboto-Regular.woff2 \
+  --flavor=woff2
+```
+
+### CSS @font-face
+
+```css
+@font-face {
+  font-family: 'Roboto';
+  src: url('/fonts/Roboto-Regular.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+}
+```
+
+## License Considerations
+
+| Use Case | Permission to Check |
+|----------|-------------------|
+| Self-hosting | "Web (Hosting)" |
+| WOFF/WOFF2 conversion | "Format Conversion" |
+| Subsetting | "Web (Subsetting)" |
+| CDN delivery | Check redistribution terms |
+
+### Best Licenses for Web
+
+- **OFL 1.1** - Allows all web uses
+- **Apache 2.0** - Fully permissive
+- **CC0** - Public domain, no restrictions
+
+### Restricted Licenses
+
+- **Platform Restricted** (Apple-only) - Cannot use on web servers
+- **Bundled Software** - Cannot extract for web use
+
+## Subsetting for Performance
+
+```bash
+# Create Latin-only subset
+pyftsubset Roboto-Regular.ttf \
+  --output-file=Roboto-Regular-latin.woff2 \
+  --flavor=woff2 \
+  --subset-latin \
+  --layout-features='*'
+```
+
+## Google Fonts Alternative
+
+For web use, you can also use Google Fonts CDN:
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+```
+
+Use Fontist when you need to:
+- Self-host for privacy/performance
+- Use fonts not on Google Fonts
+- Ensure reproducible builds
+
+## See Also
+
+- [Choosing a Formula](/formulas/guide/choosing-formula)
+- [OFL License](/formulas/licenses/ofl)

--- a/src/content/guide/what-is-formula.mdx
+++ b/src/content/guide/what-is-formula.mdx
@@ -1,0 +1,119 @@
+---
+title: What is a Formula?
+description: Understanding Fontist formulas - recipes for installing fonts
+---
+
+# What is a Formula?
+
+A **Fontist Formula** is a YAML file that describes how to download, install, and manage a font package. Think of it as a recipe for fonts - it tells Fontist where to find the fonts, how to verify them, and what fonts are included.
+
+## Key Concepts
+
+### Formula = Installation Recipe
+
+Just like a package manager has packages, Fontist has formulas. Each formula contains:
+
+- **Where** to download fonts from
+- **How** to verify downloads (SHA256 checksums)
+- **What** fonts are included (family names, styles, file names)
+- **License** information
+
+### Formula vs Font
+
+| Concept | Description |
+|---------|-------------|
+| Formula | The installation instructions (YAML file) |
+| Font | The actual font files (TTF, OTF, WOFF, etc.) |
+| Font Family | A group of related fonts (Regular, Bold, Italic, etc.) |
+
+## What's in a Formula?
+
+```yaml
+name: "Open Sans"              # Display name
+description: "Sans-serif font" # Brief description
+homepage: "https://..."        # Font homepage
+
+resources:                     # Download sources
+  font.zip:
+    urls:
+      - https://example.com/font.zip
+    sha256: "abc123..."       # Verification checksum
+
+fonts:                         # Included fonts
+  - name: "Open Sans"
+    styles:
+      - type: "Regular"
+        font: "OpenSans-Regular.ttf"
+```
+
+## Why Formulas?
+
+### Reproducible Installations
+
+Formulas ensure the same fonts are installed identically across:
+- Different machines
+- CI/CD pipelines
+- Docker containers
+- Cloud VMs
+
+### Verification
+
+Every download is verified with SHA256 checksums, ensuring:
+- Files haven't been tampered with
+- Downloads are complete and correct
+- Reproducible installations
+
+### License Awareness
+
+Formulas include license information so you can:
+- Check if a font allows your use case
+- Understand redistribution rights
+- Make informed decisions
+
+## Finding Formulas
+
+### Browse Online
+
+Visit the [Formulas Index](/formulas/) to search and browse all available formulas.
+
+### Search via CLI
+
+```bash
+fontist search "open sans"
+```
+
+### List All
+
+```bash
+fontist list
+```
+
+## Formula Sources
+
+Formulas come from various sources:
+
+| Source | Prefix | Description |
+|--------|--------|-------------|
+| Google Fonts | `google/` | 1600+ open source fonts |
+| SIL International | `sil/` | Linguistic fonts |
+| macOS System | `macos/` | Apple system fonts |
+| Expert Curated | (none) | Curated formulas |
+
+## Installing from a Formula
+
+```bash
+# Install by formula name
+fontist install "open_sans"
+
+# Install by font name (Fontist finds the formula)
+fontist install "Open Sans"
+
+# Install specific styles
+fontist install "open_sans" --style "Bold"
+```
+
+## See Also
+
+- [Formula Structure](/formulas/guide/formula-structure) - Detailed YAML structure
+- [Choosing a Formula](/formulas/guide/choosing-formula) - How to pick the right one
+- [Create a Formula](/formulas/guide/create-formula) - Make your own formula

--- a/src/content/guide/what-is-formula.mdx.bak
+++ b/src/content/guide/what-is-formula.mdx.bak
@@ -1,0 +1,119 @@
+---
+title: What is a Formula?
+description: Understanding Fontist formulas - recipes for installing fonts
+---
+
+# What is a Formula?
+
+A **Fontist Formula** is a YAML file that describes how to download, install, and manage a font package. Think of it as a recipe for fonts - it tells Fontist where to find the fonts, how to verify them, and what fonts are included.
+
+## Key Concepts
+
+### Formula = Installation Recipe
+
+Just like a package manager has packages, Fontist has formulas. Each formula contains:
+
+- **Where** to download fonts from
+- **How** to verify downloads (SHA256 checksums)
+- **What** fonts are included (family names, styles, file names)
+- **License** information
+
+### Formula vs Font
+
+| Concept | Description |
+|---------|-------------|
+| Formula | The installation instructions (YAML file) |
+| Font | The actual font files (TTF, OTF, WOFF, etc.) |
+| Font Family | A group of related fonts (Regular, Bold, Italic, etc.) |
+
+## What's in a Formula?
+
+```yaml
+name: "Open Sans"              # Display name
+description: "Sans-serif font" # Brief description
+homepage: "https://..."        # Font homepage
+
+resources:                     # Download sources
+  font.zip:
+    urls:
+      - https://example.com/font.zip
+    sha256: "abc123..."       # Verification checksum
+
+fonts:                         # Included fonts
+  - name: "Open Sans"
+    styles:
+      - type: "Regular"
+        font: "OpenSans-Regular.ttf"
+```
+
+## Why Formulas?
+
+### Reproducible Installations
+
+Formulas ensure the same fonts are installed identically across:
+- Different machines
+- CI/CD pipelines
+- Docker containers
+- Cloud VMs
+
+### Verification
+
+Every download is verified with SHA256 checksums, ensuring:
+- Files haven't been tampered with
+- Downloads are complete and correct
+- Reproducible installations
+
+### License Awareness
+
+Formulas include license information so you can:
+- Check if a font allows your use case
+- Understand redistribution rights
+- Make informed decisions
+
+## Finding Formulas
+
+### Browse Online
+
+Visit the [Formulas Index](/formulas/) to search and browse all available formulas.
+
+### Search via CLI
+
+```bash
+fontist search "open sans"
+```
+
+### List All
+
+```bash
+fontist list
+```
+
+## Formula Sources
+
+Formulas come from various sources:
+
+| Source | Prefix | Description |
+|--------|--------|-------------|
+| Google Fonts | `google/` | 1600+ open source fonts |
+| SIL International | `sil/` | Linguistic fonts |
+| macOS System | `macos/` | Apple system fonts |
+| Expert Curated | (none) | Curated formulas |
+
+## Installing from a Formula
+
+```bash
+# Install by formula name
+fontist install "open_sans"
+
+# Install by font name (Fontist finds the formula)
+fontist install "Open Sans"
+
+# Install specific styles
+fontist install "open_sans" --style "Bold"
+```
+
+## See Also
+
+- [Formula Structure](/formulas/guide/formula-structure) - Detailed YAML structure
+- [Choosing a Formula](/formulas/guide/choosing-formula) - How to pick the right one
+- [Create a Formula](/formulas/guide/create-formula) - Make your own formula

--- a/src/content/licenses/adobe.mdx
+++ b/src/content/licenses/adobe.mdx
@@ -1,0 +1,73 @@
+---
+title: "Adobe Software License"
+---
+
+# Adobe Software License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Adobe Software'%3E%3Ctitle%3ELicense: Adobe Software%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%238b5cf6' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EAdobe Software%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Adobe Software" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Bundled Software'%3E%3Ctitle%3ECategory: Bundled Software%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%238b5cf6' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EBundled Software%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Bundled Software" />
+
+**SPDX Identifier:** Not on SPDX
+
+## Quick Summary
+
+Fonts bundled with Adobe software (Reader, Acrobat, Creative Suite) can be used on any computer where the Adobe software is installed. Once installed, you may use those fonts with any application on that computer.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Viewing | ✅ Full | View PDFs and documents |
+| Printing | ✅ Full | Print documents using bundled fonts |
+| Desktop (with Adobe software) | ✅ Full | Use with any application on that computer |
+| Server/CI (with Adobe software) | ✅ Full | If Adobe software is installed |
+| Cloud VMs (with Adobe software) | ✅ Full | If Adobe software is installed |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Embedding | May be embedded in documents for viewing/printing only |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Extraction | Cannot extract fonts from Adobe software |
+| Standalone use without Adobe | Cannot use fonts without Adobe software installed |
+| Redistribution | Cannot redistribute fonts separately |
+| Modification | Cannot modify fonts |
+| Commercial redistribution | Cannot use for commercial font distribution |
+
+
+## Sample License Text
+
+From formula: `adobe_reader_19`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Adobe End-User License Agreement
+By downloading software of Adobe Systems Incorporated or its subsidiaries ("Adobe") from this site, you agree to the following terms and conditions. If you do not agree with such terms and conditions do not download the software. The terms of an end user license agreement accompanying a particular software file upon installation or download of the software shall supersede the terms presented below.
+
+The export and re-export of Adobe software products are controlled by the United States Export Administration Regulations and such software may not be exported or re-exported to Cuba, Iran, Iraq, Libya, North Korea, Sudan, Syria, or any country to which the United States embargoes goods. In addition, Adobe software may not be distributed to persons on the Table of Denial Orders, the Entity List, or the List of Specially Designated Nationals.
+
+By downloading or using an Adobe software product you are certifying that you are not a national of Cuba, Iran, Iraq, Libya, North Korea, Sudan, Syria, or any country to which the United States embargoes goods and that you are not a person on the Table of Denial Orders, the Entity List, or the List of Specially Designated Nationals.
+
+If the software is designed for use with an application software product (the "Host Application") published by Adobe, Adobe grants you a nonexclusive license to use such software with the Host Application only, provided you possess a valid license from Adobe for the Host Application. Except as set forth below, such software is licensed to you subject to the terms and conditions of the End-User License Agreement from Adobe governing your use of the Host Application.
+
+DISCLAIMER OF WARRANTIES: YOU AGREE THAT ADOBE HAS MADE NO EXPRESS WARRANTIES TO YOU REGARDING THE SOFTWARE AND THAT THE SOFTWARE IS BEING PROVIDED TO YOU "AS IS" WITHOUT WARRANTY OF ANY KIND. ADOBE DISCLAIMS ALL WARRANTIES WITH REGARD TO THE SOFTWARE, EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION, ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, MERCHANTABLE QUALITY, OR NONINFRINGEMENT OF THIRD-PARTY RIGHTS. Some states or jurisdictions do not allow the exclusion of implied warranties, so the above limitations may not apply to you.
+
+LIMIT OF LIABILITY: IN NO EVENT WILL ADOBE BE LIABLE TO YOU FOR ANY LOSS OF USE, INTERRUPTION OF BUSINESS, OR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY KIND (INCLUDING LOST PROFITS) REGARDLESS OF THE FORM OF ACTION WHETHER IN CONTRACT, TORT (INCLUDING NEGLIGENCE), STRICT PRODUCT LIABILITY OR OTHERWISE, EVEN IF ADOBE HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. Some states or jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation or exclusion may not apply to you.
+```
+
+</details>
+
+
+## See Also
+
+- [Adobe Font Licensing](https://www.adobe.com/type/legal.html)
+- [Adobe Reader](https://get.adobe.com/reader/)
+

--- a/src/content/licenses/adobe.mdx.bak
+++ b/src/content/licenses/adobe.mdx.bak
@@ -1,0 +1,69 @@
+# Adobe Software License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Adobe Software'%3E%3Ctitle%3ELicense: Adobe Software%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%238b5cf6' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EAdobe Software%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Adobe Software"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Bundled Software'%3E%3Ctitle%3ECategory: Bundled Software%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%238b5cf6' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EBundled Software%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Bundled Software">
+
+**SPDX Identifier:** Not on SPDX
+
+## Quick Summary
+
+Fonts bundled with Adobe software (Reader, Acrobat, Creative Suite) can be used on any computer where the Adobe software is installed. Once installed, you may use those fonts with any application on that computer.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Viewing | ✅ Full | View PDFs and documents |
+| Printing | ✅ Full | Print documents using bundled fonts |
+| Desktop (with Adobe software) | ✅ Full | Use with any application on that computer |
+| Server/CI (with Adobe software) | ✅ Full | If Adobe software is installed |
+| Cloud VMs (with Adobe software) | ✅ Full | If Adobe software is installed |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Embedding | May be embedded in documents for viewing/printing only |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Extraction | Cannot extract fonts from Adobe software |
+| Standalone use without Adobe | Cannot use fonts without Adobe software installed |
+| Redistribution | Cannot redistribute fonts separately |
+| Modification | Cannot modify fonts |
+| Commercial redistribution | Cannot use for commercial font distribution |
+
+
+## Sample License Text
+
+From formula: `adobe_reader_19`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Adobe End-User License Agreement
+By downloading software of Adobe Systems Incorporated or its subsidiaries ("Adobe") from this site, you agree to the following terms and conditions. If you do not agree with such terms and conditions do not download the software. The terms of an end user license agreement accompanying a particular software file upon installation or download of the software shall supersede the terms presented below.
+
+The export and re-export of Adobe software products are controlled by the United States Export Administration Regulations and such software may not be exported or re-exported to Cuba, Iran, Iraq, Libya, North Korea, Sudan, Syria, or any country to which the United States embargoes goods. In addition, Adobe software may not be distributed to persons on the Table of Denial Orders, the Entity List, or the List of Specially Designated Nationals.
+
+By downloading or using an Adobe software product you are certifying that you are not a national of Cuba, Iran, Iraq, Libya, North Korea, Sudan, Syria, or any country to which the United States embargoes goods and that you are not a person on the Table of Denial Orders, the Entity List, or the List of Specially Designated Nationals.
+
+If the software is designed for use with an application software product (the "Host Application") published by Adobe, Adobe grants you a nonexclusive license to use such software with the Host Application only, provided you possess a valid license from Adobe for the Host Application. Except as set forth below, such software is licensed to you subject to the terms and conditions of the End-User License Agreement from Adobe governing your use of the Host Application.
+
+DISCLAIMER OF WARRANTIES: YOU AGREE THAT ADOBE HAS MADE NO EXPRESS WARRANTIES TO YOU REGARDING THE SOFTWARE AND THAT THE SOFTWARE IS BEING PROVIDED TO YOU "AS IS" WITHOUT WARRANTY OF ANY KIND. ADOBE DISCLAIMS ALL WARRANTIES WITH REGARD TO THE SOFTWARE, EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION, ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, MERCHANTABLE QUALITY, OR NONINFRINGEMENT OF THIRD-PARTY RIGHTS. Some states or jurisdictions do not allow the exclusion of implied warranties, so the above limitations may not apply to you.
+
+LIMIT OF LIABILITY: IN NO EVENT WILL ADOBE BE LIABLE TO YOU FOR ANY LOSS OF USE, INTERRUPTION OF BUSINESS, OR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY KIND (INCLUDING LOST PROFITS) REGARDLESS OF THE FORM OF ACTION WHETHER IN CONTRACT, TORT (INCLUDING NEGLIGENCE), STRICT PRODUCT LIABILITY OR OTHERWISE, EVEN IF ADOBE HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. Some states or jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation or exclusion may not apply to you.
+```
+
+</details>
+
+
+## See Also
+
+- [Adobe Font Licensing](https://www.adobe.com/type/legal.html)
+- [Adobe Reader](https://get.adobe.com/reader/)
+

--- a/src/content/licenses/apache.mdx
+++ b/src/content/licenses/apache.mdx
@@ -1,0 +1,167 @@
+---
+title: "Apache License 2.0"
+---
+
+# Apache License 2.0
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Apache'%3E%3Ctitle%3ELicense: Apache%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EApache%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Apache" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source" />
+
+**SPDX Identifier:** Apache-2.0
+
+**SPDX Page:** https://spdx.org/licenses/Apache-2.0.html
+
+## Quick Summary
+
+The Apache License 2.0 is a permissive open source license that allows free use, modification, and distribution. It includes an express grant of patent rights, making it particularly suitable for fonts used in commercial products.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | Use in research, education, thesis |
+| Non-commercial | ✅ Full | Personal projects, hobbies |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, automated document generation |
+| Web (Hosting) | ✅ Full | Self-host WOFF/WOFF2/SVG |
+| Web (Subsetting) | ✅ Full | Create subsets for performance |
+| Desktop (Personal) | ✅ Full | Install on personal machines |
+| Desktop (Commercial) | ✅ Full | Install for commercial work |
+| Server/CI | ✅ Full | Install on servers, cloud |
+| Redistribution (Bundled) | ✅ Full | Include in npm/gem/any package |
+| Redistribution (Standalone) | ✅ Full | Distribute font files separately |
+| Modification | ✅ Full | Edit and redistribute |
+| Subsetting | ✅ Full | Create subset fonts |
+| Format Conversion | ✅ Full | TTF ↔ WOFF ↔ WOFF2 |
+| Commercial Documents | ✅ Full | Any commercial use |
+| Patent License | ✅ Full | Express patent grant included |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Redistribution | Must include license copy and copyright notice |
+| Modification | Must state changes made to files |
+| NOTICE file | If present, must include in derivatives |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Trademark Use | Cannot use licensor's trademarks |
+
+
+## Sample License Text
+
+From formula: `google/roboto_mono`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Copyright 2015 The Roboto Mono Project Authors (https://github.com/googlefonts/robotomono)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+```
+
+</details>
+
+
+## See Also
+
+- [Apache License 2.0 Full Text](https://www.apache.org/licenses/LICENSE-2.0)
+- [Apache License FAQ](https://www.apache.org/foundation/license-faq.html)
+- [Choose a License: Apache 2.0](https://choosealicense.com/licenses/apache-2.0/)
+

--- a/src/content/licenses/apache.mdx.bak
+++ b/src/content/licenses/apache.mdx.bak
@@ -1,0 +1,163 @@
+# Apache License 2.0
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Apache'%3E%3Ctitle%3ELicense: Apache%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EApache%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Apache"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source">
+
+**SPDX Identifier:** Apache-2.0
+
+**SPDX Page:** https://spdx.org/licenses/Apache-2.0.html
+
+## Quick Summary
+
+The Apache License 2.0 is a permissive open source license that allows free use, modification, and distribution. It includes an express grant of patent rights, making it particularly suitable for fonts used in commercial products.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | Use in research, education, thesis |
+| Non-commercial | ✅ Full | Personal projects, hobbies |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, automated document generation |
+| Web (Hosting) | ✅ Full | Self-host WOFF/WOFF2/SVG |
+| Web (Subsetting) | ✅ Full | Create subsets for performance |
+| Desktop (Personal) | ✅ Full | Install on personal machines |
+| Desktop (Commercial) | ✅ Full | Install for commercial work |
+| Server/CI | ✅ Full | Install on servers, cloud |
+| Redistribution (Bundled) | ✅ Full | Include in npm/gem/any package |
+| Redistribution (Standalone) | ✅ Full | Distribute font files separately |
+| Modification | ✅ Full | Edit and redistribute |
+| Subsetting | ✅ Full | Create subset fonts |
+| Format Conversion | ✅ Full | TTF ↔ WOFF ↔ WOFF2 |
+| Commercial Documents | ✅ Full | Any commercial use |
+| Patent License | ✅ Full | Express patent grant included |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Redistribution | Must include license copy and copyright notice |
+| Modification | Must state changes made to files |
+| NOTICE file | If present, must include in derivatives |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Trademark Use | Cannot use licensor's trademarks |
+
+
+## Sample License Text
+
+From formula: `google/roboto_mono`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Copyright 2015 The Roboto Mono Project Authors (https://github.com/googlefonts/robotomono)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+```
+
+</details>
+
+
+## See Also
+
+- [Apache License 2.0 Full Text](https://www.apache.org/licenses/LICENSE-2.0)
+- [Apache License FAQ](https://www.apache.org/foundation/license-faq.html)
+- [Choose a License: Apache 2.0](https://choosealicense.com/licenses/apache-2.0/)
+

--- a/src/content/licenses/apple-only.mdx
+++ b/src/content/licenses/apple-only.mdx
@@ -1,0 +1,122 @@
+---
+title: "Apple-only License"
+---
+
+# Apple-only License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Apple-only'%3E%3Ctitle%3ELicense: Apple-only%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%23f0ad4e' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EApple-only%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Apple-only" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Platform Restricted'%3E%3Ctitle%3ECategory: Platform Restricted%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%23f0ad4e' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EPlatform Restricted%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Platform Restricted" />
+
+**SPDX Identifier:** Not on SPDX
+
+## Quick Summary
+
+macOS and iOS system fonts are licensed by Apple for use on Apple-branded hardware only. This includes legitimate Apple virtual machines like GitHub Actions macOS runners and MacStadium.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| macOS Apps | ✅ With conditions | Must follow Apple guidelines |
+| iOS Apps | ✅ With conditions | System fonts available |
+| Documents on Mac | ✅ Full |  |
+| Cloud macOS (GitHub Actions) | ✅ Full | macOS runners are legitimate Apple hardware |
+| Cloud macOS (MacStadium) | ✅ Full | MacStadium uses Apple-branded hardware |
+| Cloud macOS (AWS EC2 Mac) | ✅ Full | AWS Mac instances are Apple hardware |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Desktop (Non-Apple) | Cannot install on Windows, Linux, Hackintosh |
+| Web (Hosting) | Cannot use @font-face for non-Apple clients |
+| Web (Subsetting) | Cannot subset for web distribution |
+| Redistribution (Standalone) | Cannot distribute font files |
+| Redistribution (Bundled) | Cannot include in npm/gem packages |
+| Modification | Cannot edit font files |
+| Resale | Cannot sell font files |
+| Format Conversion | Cannot convert to other formats |
+
+
+## Sample License Text
+
+From formula: `macos/hiragino`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+For use on Apple-branded Systems
+
+PLEASE READ THIS SOFTWARE LICENSE AGREEMENT (“LICENSE”) CAREFULLY BEFORE USING
+THE APPLE SOFTWARE. BY USING THE APPLE SOFTWARE, YOU ARE AGREEING TO BE BOUND
+BY THE TERMS OF THIS LICENSE. IF YOU DO NOT AGREE TO THE TERMS OF THIS LICENSE,
+DO NOT INSTALL AND/OR USE THE APPLE SOFTWARE AND, IF PRESENTED WITH THE OPTION
+TO “AGREE” OR “DISAGREE” TO THE TERMS, CLICK “DISAGREE”. IF YOU ACQUIRED THE
+APPLE SOFTWARE AS PART OF AN APPLE HARDWARE PURCHASE AND IF YOU DO NOT AGREE
+TO THE TERMS OF THIS LICENSE, YOU MAY RETURN THE ENTIRE APPLE HARDWARE/
+SOFTWARE PACKAGE WITHIN THE RETURN PERIOD TO THE APPLE STORE OR AUTHORIZED
+DISTRIBUTOR WHERE YOU OBTAINED IT FOR A REFUND, SUBJECT TO APPLE’S RETURN
+POLICY FOUND AT https://www.apple.com/legal/sales-support/. YOU MUST RETURN THE
+ENTIRE HARDWARE/SOFTWARE PACKAGE IN ORDER TO OBTAIN A REFUND.
+
+IMPORTANT NOTE: To the extent that this software may be used to reproduce, modify, publish or
+distribute materials, it is licensed to you only for reproduction, modification, publication and
+distribution of non-copyrighted materials, materials in which you own the copyright, or materials
+you are authorized or legally permitted to reproduce, modify, publish or distribute. If you are
+uncertain about your right to copy, modify, publish or distribute any material, you should contact
+your legal advisor.
+
+1. General.
+A. The Apple software (including Boot ROM code), any third party software, documentation, interfaces,
+content, fonts and any data accompanying this License whether preinstalled on Apple-branded
+hardware, on internal storage, on removable media, on disk, in read only memory, on any other media or
+in any other form (collectively the “Apple Software”) are licensed, not sold, to you by Apple Inc. (“Apple”)
+for use only under the terms of this License. Apple and/or Apple’s licensors retain ownership of the
+Apple Software itself and reserve all rights not expressly granted to you. You agree that the terms of this
+License will apply to any Apple-branded application software product that may be preinstalled on your
+Apple-branded hardware, unless such product is accompanied by a separate license, in which case you
+agree that the terms of that license will govern your use of that product.
+B. Apple, at its discretion, may make available future upgrades or updates to the Apple Software for your
+Apple-branded computer. Upgrades and updates, if any, may not necessarily include all existing
+software features or new features that Apple releases for newer or other models of Apple-branded
+computers. The terms of this License will govern any software upgrades or updates provided by Apple
+that replace and/or supplement the original Apple Software product, unless such upgrade or update is
+accompanied by a separate license in which case the terms of that license will govern.
+C. Title and intellectual property rights in and to any content displayed by or accessed through the Apple
+Software belongs to the respective content owner. Such content may be protected by copyright or other
+intellectual property laws and treaties, and may be subject to terms of use of the third party providing
+such content. Except as otherwise provided herein, this License does not grant you any rights to use
+such content nor does it guarantee that such content will continue to be available to you.
+2. Permitted License Uses and Restrictions.
+A. Preinstalled and Single-Copy Apple Software License. Subject to the terms and conditions of this
+License, unless you obtained the Apple Software from the Mac App Store, through an automatic
+download or under a volume license, maintenance or other written agreement from Apple, you are
+granted a limited, non-exclusive license to install, use and run one (1) copy of the Apple Software on a
+single Apple-branded computer at any one time. For example, these single-copy license terms apply to
+you if you obtained the Apple Software preinstalled on Apple-branded hardware.
+B. Mac App Store License. If you obtained a license for the Apple Software from the Mac App Store or
+through an automatic download, then subject to the terms and conditions of this License and as
+permitted by the Services and Content Usage Rules set forth in the Apple Media Services Terms and
+Conditions (https://www.apple.com/legal/internet-services/itunes/) (“Usage Rules”), you are granted a
+limited, non-transferable, non-exclusive license:
+(i) to download, install, use and run for personal, non-commercial use, one (1) copy of the Apple
+Software directly on each Apple-branded computer running macOS Catalina, macOS Mojave,
+macOS High Sierra, macOS Sierra, OS X El Capitan, OS X Yosemite, OS X Mavericks, OS X
+Mountain Lion or OS X Lion (“Mac Computer”) that you own or control;
+(ii) If you are a commercial enterprise or educational institution, to download, install, use and run
+one (1) copy of the Apple Software for use either: (a) by a single individual on each of the Mac
+Computer(s) that you own or c
+
+[... truncated for display ...]
+```
+
+</details>
+
+
+## See Also
+
+- [Apple Software License Agreement](https://www.apple.com/legal/sla/)
+- [Apple Fonts](https://developer.apple.com/fonts/)
+

--- a/src/content/licenses/apple-only.mdx.bak
+++ b/src/content/licenses/apple-only.mdx.bak
@@ -1,0 +1,118 @@
+# Apple-only License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Apple-only'%3E%3Ctitle%3ELicense: Apple-only%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%23f0ad4e' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EApple-only%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Apple-only"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Platform Restricted'%3E%3Ctitle%3ECategory: Platform Restricted%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%23f0ad4e' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EPlatform Restricted%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Platform Restricted">
+
+**SPDX Identifier:** Not on SPDX
+
+## Quick Summary
+
+macOS and iOS system fonts are licensed by Apple for use on Apple-branded hardware only. This includes legitimate Apple virtual machines like GitHub Actions macOS runners and MacStadium.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| macOS Apps | ✅ With conditions | Must follow Apple guidelines |
+| iOS Apps | ✅ With conditions | System fonts available |
+| Documents on Mac | ✅ Full |  |
+| Cloud macOS (GitHub Actions) | ✅ Full | macOS runners are legitimate Apple hardware |
+| Cloud macOS (MacStadium) | ✅ Full | MacStadium uses Apple-branded hardware |
+| Cloud macOS (AWS EC2 Mac) | ✅ Full | AWS Mac instances are Apple hardware |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Desktop (Non-Apple) | Cannot install on Windows, Linux, Hackintosh |
+| Web (Hosting) | Cannot use @font-face for non-Apple clients |
+| Web (Subsetting) | Cannot subset for web distribution |
+| Redistribution (Standalone) | Cannot distribute font files |
+| Redistribution (Bundled) | Cannot include in npm/gem packages |
+| Modification | Cannot edit font files |
+| Resale | Cannot sell font files |
+| Format Conversion | Cannot convert to other formats |
+
+
+## Sample License Text
+
+From formula: `macos/hiragino`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+For use on Apple-branded Systems
+
+PLEASE READ THIS SOFTWARE LICENSE AGREEMENT (“LICENSE”) CAREFULLY BEFORE USING
+THE APPLE SOFTWARE. BY USING THE APPLE SOFTWARE, YOU ARE AGREEING TO BE BOUND
+BY THE TERMS OF THIS LICENSE. IF YOU DO NOT AGREE TO THE TERMS OF THIS LICENSE,
+DO NOT INSTALL AND/OR USE THE APPLE SOFTWARE AND, IF PRESENTED WITH THE OPTION
+TO “AGREE” OR “DISAGREE” TO THE TERMS, CLICK “DISAGREE”. IF YOU ACQUIRED THE
+APPLE SOFTWARE AS PART OF AN APPLE HARDWARE PURCHASE AND IF YOU DO NOT AGREE
+TO THE TERMS OF THIS LICENSE, YOU MAY RETURN THE ENTIRE APPLE HARDWARE/
+SOFTWARE PACKAGE WITHIN THE RETURN PERIOD TO THE APPLE STORE OR AUTHORIZED
+DISTRIBUTOR WHERE YOU OBTAINED IT FOR A REFUND, SUBJECT TO APPLE’S RETURN
+POLICY FOUND AT https://www.apple.com/legal/sales-support/. YOU MUST RETURN THE
+ENTIRE HARDWARE/SOFTWARE PACKAGE IN ORDER TO OBTAIN A REFUND.
+
+IMPORTANT NOTE: To the extent that this software may be used to reproduce, modify, publish or
+distribute materials, it is licensed to you only for reproduction, modification, publication and
+distribution of non-copyrighted materials, materials in which you own the copyright, or materials
+you are authorized or legally permitted to reproduce, modify, publish or distribute. If you are
+uncertain about your right to copy, modify, publish or distribute any material, you should contact
+your legal advisor.
+
+1. General.
+A. The Apple software (including Boot ROM code), any third party software, documentation, interfaces,
+content, fonts and any data accompanying this License whether preinstalled on Apple-branded
+hardware, on internal storage, on removable media, on disk, in read only memory, on any other media or
+in any other form (collectively the “Apple Software”) are licensed, not sold, to you by Apple Inc. (“Apple”)
+for use only under the terms of this License. Apple and/or Apple’s licensors retain ownership of the
+Apple Software itself and reserve all rights not expressly granted to you. You agree that the terms of this
+License will apply to any Apple-branded application software product that may be preinstalled on your
+Apple-branded hardware, unless such product is accompanied by a separate license, in which case you
+agree that the terms of that license will govern your use of that product.
+B. Apple, at its discretion, may make available future upgrades or updates to the Apple Software for your
+Apple-branded computer. Upgrades and updates, if any, may not necessarily include all existing
+software features or new features that Apple releases for newer or other models of Apple-branded
+computers. The terms of this License will govern any software upgrades or updates provided by Apple
+that replace and/or supplement the original Apple Software product, unless such upgrade or update is
+accompanied by a separate license in which case the terms of that license will govern.
+C. Title and intellectual property rights in and to any content displayed by or accessed through the Apple
+Software belongs to the respective content owner. Such content may be protected by copyright or other
+intellectual property laws and treaties, and may be subject to terms of use of the third party providing
+such content. Except as otherwise provided herein, this License does not grant you any rights to use
+such content nor does it guarantee that such content will continue to be available to you.
+2. Permitted License Uses and Restrictions.
+A. Preinstalled and Single-Copy Apple Software License. Subject to the terms and conditions of this
+License, unless you obtained the Apple Software from the Mac App Store, through an automatic
+download or under a volume license, maintenance or other written agreement from Apple, you are
+granted a limited, non-exclusive license to install, use and run one (1) copy of the Apple Software on a
+single Apple-branded computer at any one time. For example, these single-copy license terms apply to
+you if you obtained the Apple Software preinstalled on Apple-branded hardware.
+B. Mac App Store License. If you obtained a license for the Apple Software from the Mac App Store or
+through an automatic download, then subject to the terms and conditions of this License and as
+permitted by the Services and Content Usage Rules set forth in the Apple Media Services Terms and
+Conditions (https://www.apple.com/legal/internet-services/itunes/) (“Usage Rules”), you are granted a
+limited, non-transferable, non-exclusive license:
+(i) to download, install, use and run for personal, non-commercial use, one (1) copy of the Apple
+Software directly on each Apple-branded computer running macOS Catalina, macOS Mojave,
+macOS High Sierra, macOS Sierra, OS X El Capitan, OS X Yosemite, OS X Mavericks, OS X
+Mountain Lion or OS X Lion (“Mac Computer”) that you own or control;
+(ii) If you are a commercial enterprise or educational institution, to download, install, use and run
+one (1) copy of the Apple Software for use either: (a) by a single individual on each of the Mac
+Computer(s) that you own or c
+
+[... truncated for display ...]
+```
+
+</details>
+
+
+## See Also
+
+- [Apple Software License Agreement](https://www.apple.com/legal/sla/)
+- [Apple Fonts](https://developer.apple.com/fonts/)
+

--- a/src/content/licenses/bitstream.mdx
+++ b/src/content/licenses/bitstream.mdx
@@ -1,0 +1,160 @@
+---
+title: "Bitstream Vera License"
+---
+
+# Bitstream Vera License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Bitstream Vera'%3E%3Ctitle%3ELicense: Bitstream Vera%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EBitstream Vera%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Bitstream Vera" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source" />
+
+**SPDX Identifier:** Bitstream-Vera
+
+**SPDX Page:** https://spdx.org/licenses/Bitstream-Vera.html
+
+## Quick Summary
+
+The Bitstream Vera License is a permissive license for the Bitstream Vera font family. It allows free use, modification, and redistribution with naming restrictions for derivative works.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full |  |
+| Non-commercial | ✅ Full |  |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, document generation |
+| Web (Hosting) | ✅ Full |  |
+| Desktop | ✅ Full |  |
+| Server/CI | ✅ Full |  |
+| Redistribution | ✅ Full | Must include license |
+| Modification | ✅ With conditions | Must rename font |
+| Format Conversion | ✅ Full |  |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Redistribution | Must include copyright and license notice |
+| Modification | Must rename font (cannot use Bitstream or Vera names) |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Standalone Sale | Cannot sell fonts by themselves |
+| Using Bitstream/Vera name | Cannot use names for modified versions |
+
+
+## Sample License Text
+
+From formula: `google/roboto`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Copyright 2011 The Roboto Project Authors (https://github.com/googlefonts/roboto-classic)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+```
+
+</details>
+
+
+## See Also
+
+- [Bitstream Vera Fonts](https://www.gnome.org/fonts/)
+- [DejaVu Fonts](https://dejavu-fonts.github.io/)
+

--- a/src/content/licenses/bitstream.mdx.bak
+++ b/src/content/licenses/bitstream.mdx.bak
@@ -1,0 +1,156 @@
+# Bitstream Vera License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Bitstream Vera'%3E%3Ctitle%3ELicense: Bitstream Vera%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EBitstream Vera%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Bitstream Vera"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source">
+
+**SPDX Identifier:** Bitstream-Vera
+
+**SPDX Page:** https://spdx.org/licenses/Bitstream-Vera.html
+
+## Quick Summary
+
+The Bitstream Vera License is a permissive license for the Bitstream Vera font family. It allows free use, modification, and redistribution with naming restrictions for derivative works.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full |  |
+| Non-commercial | ✅ Full |  |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, document generation |
+| Web (Hosting) | ✅ Full |  |
+| Desktop | ✅ Full |  |
+| Server/CI | ✅ Full |  |
+| Redistribution | ✅ Full | Must include license |
+| Modification | ✅ With conditions | Must rename font |
+| Format Conversion | ✅ Full |  |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Redistribution | Must include copyright and license notice |
+| Modification | Must rename font (cannot use Bitstream or Vera names) |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Standalone Sale | Cannot sell fonts by themselves |
+| Using Bitstream/Vera name | Cannot use names for modified versions |
+
+
+## Sample License Text
+
+From formula: `google/roboto`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Copyright 2011 The Roboto Project Authors (https://github.com/googlefonts/roboto-classic)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+```
+
+</details>
+
+
+## See Also
+
+- [Bitstream Vera Fonts](https://www.gnome.org/fonts/)
+- [DejaVu Fonts](https://dejavu-fonts.github.io/)
+

--- a/src/content/licenses/bsd.mdx
+++ b/src/content/licenses/bsd.mdx
@@ -1,0 +1,53 @@
+---
+title: "BSD License"
+---
+
+# BSD License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: BSD'%3E%3Ctitle%3ELicense: BSD%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EBSD%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: BSD" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source" />
+
+**SPDX Identifier:** BSD-2-Clause
+
+**SPDX Page:** https://spdx.org/licenses/BSD-2-Clause.html
+
+## Quick Summary
+
+The BSD License is a permissive open source license that allows free use, modification, and distribution with minimal restrictions. Only requires preservation of copyright notice and disclaimer.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full |  |
+| Non-commercial | ✅ Full |  |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, document generation |
+| Web (Hosting) | ✅ Full |  |
+| Desktop | ✅ Full |  |
+| Server/CI | ✅ Full |  |
+| Redistribution | ✅ Full | Must include copyright notice |
+| Modification | ✅ Full |  |
+| Format Conversion | ✅ Full |  |
+| Proprietary use | ✅ Full | Can include in proprietary software |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Redistribution | Must include copyright notice and license |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Using author name for endorsement | Cannot use to promote derived products |
+
+
+
+## See Also
+
+- [BSD License](https://opensource.org/licenses/BSD-2-Clause)
+- [Open Source Initiative](https://opensource.org/licenses)
+

--- a/src/content/licenses/bsd.mdx.bak
+++ b/src/content/licenses/bsd.mdx.bak
@@ -1,0 +1,49 @@
+# BSD License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: BSD'%3E%3Ctitle%3ELicense: BSD%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EBSD%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: BSD"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source">
+
+**SPDX Identifier:** BSD-2-Clause
+
+**SPDX Page:** https://spdx.org/licenses/BSD-2-Clause.html
+
+## Quick Summary
+
+The BSD License is a permissive open source license that allows free use, modification, and distribution with minimal restrictions. Only requires preservation of copyright notice and disclaimer.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full |  |
+| Non-commercial | ✅ Full |  |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, document generation |
+| Web (Hosting) | ✅ Full |  |
+| Desktop | ✅ Full |  |
+| Server/CI | ✅ Full |  |
+| Redistribution | ✅ Full | Must include copyright notice |
+| Modification | ✅ Full |  |
+| Format Conversion | ✅ Full |  |
+| Proprietary use | ✅ Full | Can include in proprietary software |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Redistribution | Must include copyright notice and license |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Using author name for endorsement | Cannot use to promote derived products |
+
+
+
+## See Also
+
+- [BSD License](https://opensource.org/licenses/BSD-2-Clause)
+- [Open Source Initiative](https://opensource.org/licenses)
+

--- a/src/content/licenses/bundled.mdx
+++ b/src/content/licenses/bundled.mdx
@@ -1,0 +1,46 @@
+---
+title: "Bundled Software License"
+---
+
+# Bundled Software License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Bundled Software'%3E%3Ctitle%3ELicense: Bundled Software%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%23ffc107' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EBundled Software%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Bundled Software" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Bundled Software'%3E%3Ctitle%3ECategory: Bundled Software%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%23ffc107' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EBundled Software%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Bundled Software" />
+
+**SPDX Identifier:** Not on SPDX
+
+## Quick Summary
+
+Fonts bundled with software applications may only be used in conjunction with that software. The license typically restricts extraction, separate use, and redistribution of the fonts outside the bundled application.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Use with bundled software | ✅ Full | Use fonts within the application |
+| Document creation | ✅ Full | Create documents using bundled fonts |
+| Printing | ✅ Full | Print documents using bundled fonts |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Embedding | May be embedded in documents created with the software |
+| Viewing | Documents can be viewed on any system |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Extraction | Cannot extract fonts from software |
+| Standalone use | Cannot use fonts outside bundled software |
+| Redistribution | Cannot redistribute fonts separately |
+| Modification | Cannot modify fonts |
+
+
+
+## See Also
+
+- [Font Licensing FAQ](https://www.fonts.com/legal/font-licensing-faq)
+

--- a/src/content/licenses/bundled.mdx.bak
+++ b/src/content/licenses/bundled.mdx.bak
@@ -1,0 +1,42 @@
+# Bundled Software License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Bundled Software'%3E%3Ctitle%3ELicense: Bundled Software%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%23ffc107' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EBundled Software%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Bundled Software"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Bundled Software'%3E%3Ctitle%3ECategory: Bundled Software%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%23ffc107' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EBundled Software%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Bundled Software">
+
+**SPDX Identifier:** Not on SPDX
+
+## Quick Summary
+
+Fonts bundled with software applications may only be used in conjunction with that software. The license typically restricts extraction, separate use, and redistribution of the fonts outside the bundled application.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Use with bundled software | ✅ Full | Use fonts within the application |
+| Document creation | ✅ Full | Create documents using bundled fonts |
+| Printing | ✅ Full | Print documents using bundled fonts |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Embedding | May be embedded in documents created with the software |
+| Viewing | Documents can be viewed on any system |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Extraction | Cannot extract fonts from software |
+| Standalone use | Cannot use fonts outside bundled software |
+| Redistribution | Cannot redistribute fonts separately |
+| Modification | Cannot modify fonts |
+
+
+
+## See Also
+
+- [Font Licensing FAQ](https://www.fonts.com/legal/font-licensing-faq)
+

--- a/src/content/licenses/cc-by-sa.mdx
+++ b/src/content/licenses/cc-by-sa.mdx
@@ -1,0 +1,54 @@
+---
+title: "Creative Commons Attribution-ShareAlike 4.0"
+---
+
+# Creative Commons Attribution-ShareAlike 4.0
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Creative Commons Attribution-ShareAlike 4.0'%3E%3Ctitle%3ELicense: Creative Commons Attribution-ShareAlike 4.0%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3ECreative Commons Attribution-ShareAlike 4.0%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Creative Commons Attribution-ShareAlike 4.0" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source" />
+
+**SPDX Identifier:** CC-BY-SA-4.0
+
+**SPDX Page:** https://spdx.org/licenses/CC-BY-SA-4.0.html
+
+## Quick Summary
+
+The CC-BY-SA 4.0 license allows free use, modification, and distribution with attribution. Derivative works must be licensed under the same terms. Commonly used for fonts with design contributions from multiple sources.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | With attribution |
+| Non-commercial | ✅ Full | With attribution |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials with attribution |
+| Commercial (Server) | ✅ Full | CI/CD, document generation with attribution |
+| Web (Hosting) | ✅ Full | With attribution |
+| Desktop | ✅ Full |  |
+| Server/CI | ✅ Full |  |
+| Redistribution | ✅ Full | With attribution and same license |
+| Modification | ✅ Full | Must use CC-BY-SA license |
+| Format Conversion | ✅ Full |  |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Any use | Must provide attribution |
+| Derivative works | Must use CC-BY-SA license |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Use without attribution | Attribution required |
+| Proprietary derivatives | Cannot change to more restrictive license |
+
+
+
+## See Also
+
+- [CC BY-SA 4.0 License](https://creativecommons.org/licenses/by-sa/4.0/)
+- [Creative Commons License Chooser](https://creativecommons.org/choose/)
+

--- a/src/content/licenses/cc-by-sa.mdx.bak
+++ b/src/content/licenses/cc-by-sa.mdx.bak
@@ -1,0 +1,50 @@
+# Creative Commons Attribution-ShareAlike 4.0
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Creative Commons Attribution-ShareAlike 4.0'%3E%3Ctitle%3ELicense: Creative Commons Attribution-ShareAlike 4.0%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3ECreative Commons Attribution-ShareAlike 4.0%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Creative Commons Attribution-ShareAlike 4.0"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source">
+
+**SPDX Identifier:** CC-BY-SA-4.0
+
+**SPDX Page:** https://spdx.org/licenses/CC-BY-SA-4.0.html
+
+## Quick Summary
+
+The CC-BY-SA 4.0 license allows free use, modification, and distribution with attribution. Derivative works must be licensed under the same terms. Commonly used for fonts with design contributions from multiple sources.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | With attribution |
+| Non-commercial | ✅ Full | With attribution |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials with attribution |
+| Commercial (Server) | ✅ Full | CI/CD, document generation with attribution |
+| Web (Hosting) | ✅ Full | With attribution |
+| Desktop | ✅ Full |  |
+| Server/CI | ✅ Full |  |
+| Redistribution | ✅ Full | With attribution and same license |
+| Modification | ✅ Full | Must use CC-BY-SA license |
+| Format Conversion | ✅ Full |  |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Any use | Must provide attribution |
+| Derivative works | Must use CC-BY-SA license |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Use without attribution | Attribution required |
+| Proprietary derivatives | Cannot change to more restrictive license |
+
+
+
+## See Also
+
+- [CC BY-SA 4.0 License](https://creativecommons.org/licenses/by-sa/4.0/)
+- [Creative Commons License Chooser](https://creativecommons.org/choose/)
+

--- a/src/content/licenses/cc-by.mdx
+++ b/src/content/licenses/cc-by.mdx
@@ -1,0 +1,160 @@
+---
+title: "Creative Commons Attribution 4.0"
+---
+
+# Creative Commons Attribution 4.0
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Creative Commons Attribution 4.0'%3E%3Ctitle%3ELicense: Creative Commons Attribution 4.0%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3ECreative Commons Attribution 4.0%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Creative Commons Attribution 4.0" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source" />
+
+**SPDX Identifier:** CC-BY-4.0
+
+**SPDX Page:** https://spdx.org/licenses/CC-BY-4.0.html
+
+## Quick Summary
+
+The Creative Commons Attribution license allows free use, modification, and distribution with only one requirement - you must give appropriate credit to the original creator.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | Must attribute |
+| Non-commercial | ✅ Full | Must attribute |
+| Commercial (Static) | ✅ Full | Must attribute |
+| Commercial (Server) | ✅ Full | Must attribute |
+| Web (Hosting) | ✅ Full | Must attribute |
+| Web (Subsetting) | ✅ Full | Must attribute |
+| Desktop (Personal) | ✅ Full | Must attribute |
+| Desktop (Commercial) | ✅ Full | Must attribute |
+| Server/CI | ✅ Full | Must attribute |
+| Redistribution (Bundled) | ✅ Full | Must attribute |
+| Redistribution (Standalone) | ✅ Full | Must attribute |
+| Modification | ✅ Full | Must attribute |
+| Subsetting | ✅ Full | Must attribute |
+| Format Conversion | ✅ Full | Must attribute |
+| Commercial Documents | ✅ Full | Must attribute |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Any use | Must provide attribution to creator |
+| Modification | Must indicate changes made |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| No attribution | Cannot use without giving credit |
+
+
+## Sample License Text
+
+From formula: `seshat`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+    communicate, and translate a Work;
+ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+    likeness depicted in a Work;
+iv. rights protecting against unfair competition in regards to a Work,
+    subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+    in a Work;
+vi. database rights (such as those arising under Directive 96/9/EC of the
+    European Parliament and of the Council of 11 March 1996 on the legal
+    protection of databases, and under any national implementation
+    thereof, including any amended or successor version of such
+    directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+    world based on applicable law or treaty, and any national
+    implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or t
+
+[... truncated for display ...]
+```
+
+</details>
+
+
+## See Also
+
+- [Creative Commons CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
+- [SPDX: CC-BY-4.0](https://spdx.org/licenses/CC-BY-4.0.html)
+

--- a/src/content/licenses/cc-by.mdx.bak
+++ b/src/content/licenses/cc-by.mdx.bak
@@ -1,0 +1,156 @@
+# Creative Commons Attribution 4.0
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Creative Commons Attribution 4.0'%3E%3Ctitle%3ELicense: Creative Commons Attribution 4.0%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3ECreative Commons Attribution 4.0%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Creative Commons Attribution 4.0"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source">
+
+**SPDX Identifier:** CC-BY-4.0
+
+**SPDX Page:** https://spdx.org/licenses/CC-BY-4.0.html
+
+## Quick Summary
+
+The Creative Commons Attribution license allows free use, modification, and distribution with only one requirement - you must give appropriate credit to the original creator.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | Must attribute |
+| Non-commercial | ✅ Full | Must attribute |
+| Commercial (Static) | ✅ Full | Must attribute |
+| Commercial (Server) | ✅ Full | Must attribute |
+| Web (Hosting) | ✅ Full | Must attribute |
+| Web (Subsetting) | ✅ Full | Must attribute |
+| Desktop (Personal) | ✅ Full | Must attribute |
+| Desktop (Commercial) | ✅ Full | Must attribute |
+| Server/CI | ✅ Full | Must attribute |
+| Redistribution (Bundled) | ✅ Full | Must attribute |
+| Redistribution (Standalone) | ✅ Full | Must attribute |
+| Modification | ✅ Full | Must attribute |
+| Subsetting | ✅ Full | Must attribute |
+| Format Conversion | ✅ Full | Must attribute |
+| Commercial Documents | ✅ Full | Must attribute |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Any use | Must provide attribution to creator |
+| Modification | Must indicate changes made |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| No attribution | Cannot use without giving credit |
+
+
+## Sample License Text
+
+From formula: `seshat`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+    communicate, and translate a Work;
+ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+    likeness depicted in a Work;
+iv. rights protecting against unfair competition in regards to a Work,
+    subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+    in a Work;
+vi. database rights (such as those arising under Directive 96/9/EC of the
+    European Parliament and of the Council of 11 March 1996 on the legal
+    protection of databases, and under any national implementation
+    thereof, including any amended or successor version of such
+    directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+    world based on applicable law or treaty, and any national
+    implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or t
+
+[... truncated for display ...]
+```
+
+</details>
+
+
+## See Also
+
+- [Creative Commons CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
+- [SPDX: CC-BY-4.0](https://spdx.org/licenses/CC-BY-4.0.html)
+

--- a/src/content/licenses/cc0.mdx
+++ b/src/content/licenses/cc0.mdx
@@ -1,0 +1,153 @@
+---
+title: "Creative Commons Zero (Public Domain)"
+---
+
+# Creative Commons Zero (Public Domain)
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Creative Commons Zero (Public Domain)'%3E%3Ctitle%3ELicense: Creative Commons Zero (Public Domain)%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3ECreative Commons Zero (Public Domain)%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Creative Commons Zero (Public Domain)" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source" />
+
+**SPDX Identifier:** CC0-1.0
+
+**SPDX Page:** https://spdx.org/licenses/CC0-1.0.html
+
+## Quick Summary
+
+CC0 (Creative Commons Zero) is a public domain dedication. Works under CC0 have no copyright restrictions whatsoever - you can do anything with them without attribution or conditions.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | No restrictions |
+| Non-commercial | ✅ Full | No restrictions |
+| Commercial (Static) | ✅ Full | No restrictions |
+| Commercial (Server) | ✅ Full | No restrictions |
+| Web (Hosting) | ✅ Full | No restrictions |
+| Web (Subsetting) | ✅ Full | No restrictions |
+| Desktop (Personal) | ✅ Full | No restrictions |
+| Desktop (Commercial) | ✅ Full | No restrictions |
+| Server/CI | ✅ Full | No restrictions |
+| Redistribution (Bundled) | ✅ Full | No restrictions |
+| Redistribution (Standalone) | ✅ Full | No restrictions |
+| Modification | ✅ Full | No restrictions |
+| Subsetting | ✅ Full | No restrictions |
+| Format Conversion | ✅ Full | No restrictions |
+| Commercial Documents | ✅ Full | No restrictions |
+| Sale | ✅ Full | Can even sell the fonts themselves |
+| Attribution | ✅ Optional | Not legally required |
+
+
+## Sample License Text
+
+From formula: `google/roboto`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Copyright 2011 The Roboto Project Authors (https://github.com/googlefonts/roboto-classic)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+```
+
+</details>
+
+
+## See Also
+
+- [Creative Commons CC0](https://creativecommons.org/publicdomain/zero/1.0/)
+- [SPDX: CC0-1.0](https://spdx.org/licenses/CC0-1.0.html)
+

--- a/src/content/licenses/cc0.mdx.bak
+++ b/src/content/licenses/cc0.mdx.bak
@@ -1,0 +1,149 @@
+# Creative Commons Zero (Public Domain)
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Creative Commons Zero (Public Domain)'%3E%3Ctitle%3ELicense: Creative Commons Zero (Public Domain)%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3ECreative Commons Zero (Public Domain)%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Creative Commons Zero (Public Domain)"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source">
+
+**SPDX Identifier:** CC0-1.0
+
+**SPDX Page:** https://spdx.org/licenses/CC0-1.0.html
+
+## Quick Summary
+
+CC0 (Creative Commons Zero) is a public domain dedication. Works under CC0 have no copyright restrictions whatsoever - you can do anything with them without attribution or conditions.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | No restrictions |
+| Non-commercial | ✅ Full | No restrictions |
+| Commercial (Static) | ✅ Full | No restrictions |
+| Commercial (Server) | ✅ Full | No restrictions |
+| Web (Hosting) | ✅ Full | No restrictions |
+| Web (Subsetting) | ✅ Full | No restrictions |
+| Desktop (Personal) | ✅ Full | No restrictions |
+| Desktop (Commercial) | ✅ Full | No restrictions |
+| Server/CI | ✅ Full | No restrictions |
+| Redistribution (Bundled) | ✅ Full | No restrictions |
+| Redistribution (Standalone) | ✅ Full | No restrictions |
+| Modification | ✅ Full | No restrictions |
+| Subsetting | ✅ Full | No restrictions |
+| Format Conversion | ✅ Full | No restrictions |
+| Commercial Documents | ✅ Full | No restrictions |
+| Sale | ✅ Full | Can even sell the fonts themselves |
+| Attribution | ✅ Optional | Not legally required |
+
+
+## Sample License Text
+
+From formula: `google/roboto`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Copyright 2011 The Roboto Project Authors (https://github.com/googlefonts/roboto-classic)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+```
+
+</details>
+
+
+## See Also
+
+- [Creative Commons CC0](https://creativecommons.org/publicdomain/zero/1.0/)
+- [SPDX: CC0-1.0](https://spdx.org/licenses/CC0-1.0.html)
+

--- a/src/content/licenses/free-use.mdx
+++ b/src/content/licenses/free-use.mdx
@@ -1,0 +1,156 @@
+---
+title: "Freely Usable Fonts"
+---
+
+# Freely Usable Fonts
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Freely Usable Fonts'%3E%3Ctitle%3ELicense: Freely Usable Fonts%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2317a2b8' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EFreely Usable Fonts%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Freely Usable Fonts" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Freely Distributable'%3E%3Ctitle%3ECategory: Freely Distributable%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2317a2b8' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EFreely Distributable%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Freely Distributable" />
+
+**SPDX Identifier:** Not on SPDX
+
+## Quick Summary
+
+Freely usable fonts can be used without payment for most purposes, including commercial use. They may have minimal restrictions but are generally available for broad use without licensing fees.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full |  |
+| Non-commercial | ✅ Full |  |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, document generation |
+| Web (Hosting) | ✅ Full |  |
+| Desktop | ✅ Full |  |
+| Server/CI | ✅ Full |  |
+| Redistribution | ✅ Full | Check specific license |
+| Format Conversion | ✅ Full |  |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Modification | Check specific font license |
+| Attribution | Some may require attribution |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Standalone Sale | Usually not allowed |
+
+
+## Sample License Text
+
+From formula: `google/abel`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Copyright (c) 2011, Matthew Desmond (http://www.madtype.com | mattdesmond@gmail.com),with Reserved Font Name Abel.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+```
+
+</details>
+
+
+## See Also
+
+- [Google Fonts](https://fonts.google.com/)
+- [Font Squirrel](https://www.fontsquirrel.com/)
+

--- a/src/content/licenses/free-use.mdx.bak
+++ b/src/content/licenses/free-use.mdx.bak
@@ -1,0 +1,152 @@
+# Freely Usable Fonts
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Freely Usable Fonts'%3E%3Ctitle%3ELicense: Freely Usable Fonts%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2317a2b8' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EFreely Usable Fonts%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Freely Usable Fonts"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Freely Distributable'%3E%3Ctitle%3ECategory: Freely Distributable%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2317a2b8' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EFreely Distributable%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Freely Distributable">
+
+**SPDX Identifier:** Not on SPDX
+
+## Quick Summary
+
+Freely usable fonts can be used without payment for most purposes, including commercial use. They may have minimal restrictions but are generally available for broad use without licensing fees.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full |  |
+| Non-commercial | ✅ Full |  |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, document generation |
+| Web (Hosting) | ✅ Full |  |
+| Desktop | ✅ Full |  |
+| Server/CI | ✅ Full |  |
+| Redistribution | ✅ Full | Check specific license |
+| Format Conversion | ✅ Full |  |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Modification | Check specific font license |
+| Attribution | Some may require attribution |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Standalone Sale | Usually not allowed |
+
+
+## Sample License Text
+
+From formula: `google/abel`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Copyright (c) 2011, Matthew Desmond (http://www.madtype.com | mattdesmond@gmail.com),with Reserved Font Name Abel.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+```
+
+</details>
+
+
+## See Also
+
+- [Google Fonts](https://fonts.google.com/)
+- [Font Squirrel](https://www.fontsquirrel.com/)
+

--- a/src/content/licenses/freeware.mdx
+++ b/src/content/licenses/freeware.mdx
@@ -1,0 +1,154 @@
+---
+title: "Freeware Font License"
+---
+
+# Freeware Font License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Freeware Font'%3E%3Ctitle%3ELicense: Freeware Font%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2317a2b8' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EFreeware Font%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Freeware Font" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Freely Distributable'%3E%3Ctitle%3ECategory: Freely Distributable%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2317a2b8' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EFreely Distributable%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Freely Distributable" />
+
+**SPDX Identifier:** Not on SPDX
+
+## Quick Summary
+
+Freeware fonts are free to use but may have restrictions on modification, redistribution, or commercial use. Each freeware font has its own specific license terms that should be reviewed individually.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | Typically allowed |
+| Non-commercial | ✅ Full | Usually free for personal use |
+| Commercial (Static) | ✅ Varies | Check specific license |
+| Desktop | ✅ Full | Usually allowed for personal use |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Commercial use | Check specific font license |
+| Redistribution | Often requires permission |
+| Modification | Usually requires permission |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Redistribution | Often not allowed without permission |
+| Modification | Often not allowed |
+| Sale | Cannot sell freeware fonts |
+
+
+## Sample License Text
+
+From formula: `google/abel`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Copyright (c) 2011, Matthew Desmond (http://www.madtype.com | mattdesmond@gmail.com),with Reserved Font Name Abel.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+```
+
+</details>
+
+
+## See Also
+
+- [Font Squirrel Freeware](https://www.fontsquirrel.com/)
+- [DaFont License Info](https://www.dafont.com/faq.php)
+

--- a/src/content/licenses/freeware.mdx.bak
+++ b/src/content/licenses/freeware.mdx.bak
@@ -1,0 +1,150 @@
+# Freeware Font License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Freeware Font'%3E%3Ctitle%3ELicense: Freeware Font%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2317a2b8' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EFreeware Font%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Freeware Font"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Freely Distributable'%3E%3Ctitle%3ECategory: Freely Distributable%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2317a2b8' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EFreely Distributable%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Freely Distributable">
+
+**SPDX Identifier:** Not on SPDX
+
+## Quick Summary
+
+Freeware fonts are free to use but may have restrictions on modification, redistribution, or commercial use. Each freeware font has its own specific license terms that should be reviewed individually.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | Typically allowed |
+| Non-commercial | ✅ Full | Usually free for personal use |
+| Commercial (Static) | ✅ Varies | Check specific license |
+| Desktop | ✅ Full | Usually allowed for personal use |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Commercial use | Check specific font license |
+| Redistribution | Often requires permission |
+| Modification | Usually requires permission |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Redistribution | Often not allowed without permission |
+| Modification | Often not allowed |
+| Sale | Cannot sell freeware fonts |
+
+
+## Sample License Text
+
+From formula: `google/abel`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Copyright (c) 2011, Matthew Desmond (http://www.madtype.com | mattdesmond@gmail.com),with Reserved Font Name Abel.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+```
+
+</details>
+
+
+## See Also
+
+- [Font Squirrel Freeware](https://www.fontsquirrel.com/)
+- [DaFont License Info](https://www.dafont.com/faq.php)
+

--- a/src/content/licenses/gpl.mdx
+++ b/src/content/licenses/gpl.mdx
@@ -1,0 +1,163 @@
+---
+title: "GNU General Public License"
+---
+
+# GNU General Public License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: GNU General Public'%3E%3Ctitle%3ELicense: GNU General Public%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EGNU General Public%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: GNU General Public" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source" />
+
+**SPDX Identifier:** GPL-2.0 or GPL-3.0 (with Font Exception)
+
+**SPDX Page:** https://spdx.org/licenses/GPL-3.0.html
+
+## Quick Summary
+
+The GNU General Public License is a copyleft license that requires derivative works to be distributed under the same license terms. For fonts, a special font exception often applies allowing embedding in documents.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | Use in research, education |
+| Non-commercial | ✅ Full | Personal projects |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, document generation |
+| Web (Hosting) | ✅ Full | Self-host WOFF/WOFF2 |
+| Desktop | ✅ Full | Install on any machine |
+| Server/CI | ✅ Full | Install on servers |
+| Redistribution (Bundled) | ✅ Full | Include in packages with same license |
+| Modification | ✅ With conditions | Must use GPL license |
+| Format Conversion | ✅ Full | TTF ↔ WOFF ↔ WOFF2 |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Redistribution | Must distribute under GPL with source code |
+| Modification | Derivative works must use GPL license |
+| Embedding in documents | Font exception allows embedding without document being GPL |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Proprietary use | Cannot use in closed-source software without font exception |
+| Standalone Sale | Cannot sell fonts by themselves |
+
+
+## Sample License Text
+
+From formula: `liberation`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Digitized data copyright (c) 2010 Google Corporation
+  with Reserved Font Arimo, Tinos and Cousine.
+Copyright (c) 2012 Red Hat, Inc.
+  with Reserved Font Name Liberation.
+
+This Font Software is licensed under the SIL Open Font License,
+Version 1.1.
+
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+
+PREAMBLE The goals of the Open Font License (OFL) are to stimulate
+worldwide development of collaborative font projects, to support the font
+creation efforts of academic and linguistic communities, and to provide
+a free and open framework in which fonts may be shared and improved in
+partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves.
+The fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works.  The fonts and derivatives,
+however, cannot be released under any other type of license.  The
+requirement for fonts to remain under this license does not apply to
+any document created using the fonts or their derivatives.
+
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such.
+This may include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components
+as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting ? in part or in whole ?
+any of the components of the Original Version, by changing formats or
+by porting the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical writer
+or other person who contributed to the Font Software.
+
+
+PERMISSION & CONDITIONS
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,in
+  Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+  redistributed and/or sold with any software, provided that each copy
+  contains the above copyright notice and this license. These can be
+  included either as stand-alone text files, human-readable headers or
+  in the appropriate machine-readable metadata fields within text or
+  binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+  Name(s) unless explicit written permission is granted by the
+  corresponding Copyright Holder. This restriction only applies to the
+  primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+  Software shall not be used to promote, endorse or advertise any
+  Modified Version, except to acknowledge the contribution(s) of the
+  Copyright Holder(s) and the Author(s) or with their explicit written
+  permission.
+
+5) The Font Software, modified or unmodified, in part or in whole, must
+  be distributed entirely under this license, and must not be distributed
+  under any other license. The requirement for fonts to remain under
+  this license does not apply to any document created using the Font
+  Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT.  IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER
+DEALINGS IN THE FONT SOFTWARE.
+```
+
+</details>
+
+
+## See Also
+
+- [GNU GPL License](https://www.gnu.org/licenses/gpl-3.0.html)
+- [Font Exception](https://www.gnu.org/licenses/gpl-faq.html#FontException)
+

--- a/src/content/licenses/gpl.mdx.bak
+++ b/src/content/licenses/gpl.mdx.bak
@@ -1,0 +1,159 @@
+# GNU General Public License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: GNU General Public'%3E%3Ctitle%3ELicense: GNU General Public%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EGNU General Public%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: GNU General Public"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source">
+
+**SPDX Identifier:** GPL-2.0 or GPL-3.0 (with Font Exception)
+
+**SPDX Page:** https://spdx.org/licenses/GPL-3.0.html
+
+## Quick Summary
+
+The GNU General Public License is a copyleft license that requires derivative works to be distributed under the same license terms. For fonts, a special font exception often applies allowing embedding in documents.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | Use in research, education |
+| Non-commercial | ✅ Full | Personal projects |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, document generation |
+| Web (Hosting) | ✅ Full | Self-host WOFF/WOFF2 |
+| Desktop | ✅ Full | Install on any machine |
+| Server/CI | ✅ Full | Install on servers |
+| Redistribution (Bundled) | ✅ Full | Include in packages with same license |
+| Modification | ✅ With conditions | Must use GPL license |
+| Format Conversion | ✅ Full | TTF ↔ WOFF ↔ WOFF2 |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Redistribution | Must distribute under GPL with source code |
+| Modification | Derivative works must use GPL license |
+| Embedding in documents | Font exception allows embedding without document being GPL |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Proprietary use | Cannot use in closed-source software without font exception |
+| Standalone Sale | Cannot sell fonts by themselves |
+
+
+## Sample License Text
+
+From formula: `liberation`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Digitized data copyright (c) 2010 Google Corporation
+  with Reserved Font Arimo, Tinos and Cousine.
+Copyright (c) 2012 Red Hat, Inc.
+  with Reserved Font Name Liberation.
+
+This Font Software is licensed under the SIL Open Font License,
+Version 1.1.
+
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+
+PREAMBLE The goals of the Open Font License (OFL) are to stimulate
+worldwide development of collaborative font projects, to support the font
+creation efforts of academic and linguistic communities, and to provide
+a free and open framework in which fonts may be shared and improved in
+partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves.
+The fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works.  The fonts and derivatives,
+however, cannot be released under any other type of license.  The
+requirement for fonts to remain under this license does not apply to
+any document created using the fonts or their derivatives.
+
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such.
+This may include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components
+as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting ? in part or in whole ?
+any of the components of the Original Version, by changing formats or
+by porting the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical writer
+or other person who contributed to the Font Software.
+
+
+PERMISSION & CONDITIONS
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,in
+  Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+  redistributed and/or sold with any software, provided that each copy
+  contains the above copyright notice and this license. These can be
+  included either as stand-alone text files, human-readable headers or
+  in the appropriate machine-readable metadata fields within text or
+  binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+  Name(s) unless explicit written permission is granted by the
+  corresponding Copyright Holder. This restriction only applies to the
+  primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+  Software shall not be used to promote, endorse or advertise any
+  Modified Version, except to acknowledge the contribution(s) of the
+  Copyright Holder(s) and the Author(s) or with their explicit written
+  permission.
+
+5) The Font Software, modified or unmodified, in part or in whole, must
+  be distributed entirely under this license, and must not be distributed
+  under any other license. The requirement for fonts to remain under
+  this license does not apply to any document created using the Font
+  Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT.  IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER
+DEALINGS IN THE FONT SOFTWARE.
+```
+
+</details>
+
+
+## See Also
+
+- [GNU GPL License](https://www.gnu.org/licenses/gpl-3.0.html)
+- [Font Exception](https://www.gnu.org/licenses/gpl-faq.html#FontException)
+

--- a/src/content/licenses/gust.mdx
+++ b/src/content/licenses/gust.mdx
@@ -1,0 +1,93 @@
+---
+title: "GUST Font License"
+---
+
+# GUST Font License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: GUST Font'%3E%3Ctitle%3ELicense: GUST Font%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EGUST Font%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: GUST Font" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source" />
+
+**SPDX Identifier:** Not on SPDX
+
+## Quick Summary
+
+The GUST Font License is a permissive license used primarily by the GUST (Dutch "Gebruikersgroep U TeX") group for TeX-related fonts. It allows free use, modification, and redistribution.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full |  |
+| Non-commercial | ✅ Full |  |
+| Commercial (Static) | ✅ Full |  |
+| Commercial (Server) | ✅ Full |  |
+| Web (Hosting) | ✅ Full |  |
+| Web (Subsetting) | ✅ Full |  |
+| Desktop | ✅ Full |  |
+| Server/CI | ✅ Full |  |
+| Redistribution | ✅ Full | Must include license |
+| Modification | ✅ Full | Must rename |
+| Format Conversion | ✅ Full |  |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Redistribution | Must include license and copyright notice |
+| Modification | Must rename the font |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Sale | Cannot sell fonts by themselves |
+
+
+## Sample License Text
+
+From formula: `tex_gyre_math`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+% This is a preliminary version (2006-09-30), barring acceptance from
+% the LaTeX Project Team and other feedback, of the GUST Font License.
+% (GUST is the Polish TeX Users Group, http://www.gust.org.pl)
+%
+% For the most recent version of this license see
+% http://www.gust.org.pl/fonts/licenses/GUST-FONT-LICENSE.txt
+% or
+% http://tug.org/fonts/licenses/GUST-FONT-LICENSE.txt
+%
+% This work may be distributed and/or modified under the conditions
+% of the LaTeX Project Public License, either version 1.3c of this
+% license or (at your option) any later version.
+%
+% Please also observe the following clause:
+% 1) it is requested, but not legally required, that derived works be
+%    distributed only after changing the names of the fonts comprising this
+%    work and given in an accompanying "manifest", and that the
+%    files comprising the Work, as listed in the manifest, also be given
+%    new names. Any exceptions to this request are also given in the
+%    manifest.
+%
+%    We recommend the manifest be given in a separate file named
+%    MANIFEST-<fontid>.txt, where <fontid> is some unique identification
+%    of the font family. If a separate "readme" file accompanies the Work,
+%    we recommend a name of the form README-<fontid>.txt.
+%
+% The latest version of the LaTeX Project Public License is in
+% http://www.latex-project.org/lppl.txt and version 1.3c or later
+% is part of all distributions of LaTeX version 2006/05/20 or later.
+```
+
+</details>
+
+
+## See Also
+
+- [GUST Font License](http://www.gust.org.pl/fonts/licenses/GUST-FONT-LICENSE.txt)
+- [TeX Gyre Fonts](http://www.gust.org.pl/projects/e-foundry/tex-gyre)
+

--- a/src/content/licenses/gust.mdx.bak
+++ b/src/content/licenses/gust.mdx.bak
@@ -1,0 +1,89 @@
+# GUST Font License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: GUST Font'%3E%3Ctitle%3ELicense: GUST Font%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EGUST Font%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: GUST Font"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source">
+
+**SPDX Identifier:** Not on SPDX
+
+## Quick Summary
+
+The GUST Font License is a permissive license used primarily by the GUST (Dutch "Gebruikersgroep U TeX") group for TeX-related fonts. It allows free use, modification, and redistribution.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full |  |
+| Non-commercial | ✅ Full |  |
+| Commercial (Static) | ✅ Full |  |
+| Commercial (Server) | ✅ Full |  |
+| Web (Hosting) | ✅ Full |  |
+| Web (Subsetting) | ✅ Full |  |
+| Desktop | ✅ Full |  |
+| Server/CI | ✅ Full |  |
+| Redistribution | ✅ Full | Must include license |
+| Modification | ✅ Full | Must rename |
+| Format Conversion | ✅ Full |  |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Redistribution | Must include license and copyright notice |
+| Modification | Must rename the font |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Sale | Cannot sell fonts by themselves |
+
+
+## Sample License Text
+
+From formula: `tex_gyre_math`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+% This is a preliminary version (2006-09-30), barring acceptance from
+% the LaTeX Project Team and other feedback, of the GUST Font License.
+% (GUST is the Polish TeX Users Group, http://www.gust.org.pl)
+%
+% For the most recent version of this license see
+% http://www.gust.org.pl/fonts/licenses/GUST-FONT-LICENSE.txt
+% or
+% http://tug.org/fonts/licenses/GUST-FONT-LICENSE.txt
+%
+% This work may be distributed and/or modified under the conditions
+% of the LaTeX Project Public License, either version 1.3c of this
+% license or (at your option) any later version.
+%
+% Please also observe the following clause:
+% 1) it is requested, but not legally required, that derived works be
+%    distributed only after changing the names of the fonts comprising this
+%    work and given in an accompanying "manifest", and that the
+%    files comprising the Work, as listed in the manifest, also be given
+%    new names. Any exceptions to this request are also given in the
+%    manifest.
+%
+%    We recommend the manifest be given in a separate file named
+%    MANIFEST-<fontid>.txt, where <fontid> is some unique identification
+%    of the font family. If a separate "readme" file accompanies the Work,
+%    we recommend a name of the form README-<fontid>.txt.
+%
+% The latest version of the LaTeX Project Public License is in
+% http://www.latex-project.org/lppl.txt and version 1.3c or later
+% is part of all distributions of LaTeX version 2006/05/20 or later.
+```
+
+</details>
+
+
+## See Also
+
+- [GUST Font License](http://www.gust.org.pl/fonts/licenses/GUST-FONT-LICENSE.txt)
+- [TeX Gyre Fonts](http://www.gust.org.pl/projects/e-foundry/tex-gyre)
+

--- a/src/content/licenses/ipa.mdx
+++ b/src/content/licenses/ipa.mdx
@@ -1,0 +1,54 @@
+---
+title: "IPA Font License"
+---
+
+# IPA Font License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: IPA Font'%3E%3Ctitle%3ELicense: IPA Font%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EIPA Font%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: IPA Font" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source" />
+
+**SPDX Identifier:** IPA
+
+**SPDX Page:** https://spdx.org/licenses/IPA.html
+
+## Quick Summary
+
+The IPA Font License is an open source license created by the Information-technology Promotion Agency (IPA) of Japan. It allows free use, modification, and redistribution with specific requirements for derivative works.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | Use in research, education |
+| Non-commercial | ✅ Full | Personal projects |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, document generation |
+| Web (Hosting) | ✅ Full | Self-host WOFF/WOFF2 |
+| Desktop | ✅ Full | Install on any machine |
+| Server/CI | ✅ Full | Install on servers |
+| Redistribution (Bundled) | ✅ Full | Include in packages |
+| Modification | ✅ With conditions | Must rename font |
+| Format Conversion | ✅ Full | TTF ↔ WOFF ↔ WOFF2 |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Redistribution of modified fonts | Must include source files and means to replace with original |
+| Modification | Must not use original font name |
+| Derivative works | Must license under IPA license |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Using original name | Cannot use original font name for modified versions |
+
+
+
+## See Also
+
+- [IPA Font License](https://opensource.org/licenses/IPA/)
+- [IPA Fonts](https://moji.or.jp/ipafont/)
+

--- a/src/content/licenses/ipa.mdx.bak
+++ b/src/content/licenses/ipa.mdx.bak
@@ -1,0 +1,50 @@
+# IPA Font License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: IPA Font'%3E%3Ctitle%3ELicense: IPA Font%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EIPA Font%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: IPA Font"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source">
+
+**SPDX Identifier:** IPA
+
+**SPDX Page:** https://spdx.org/licenses/IPA.html
+
+## Quick Summary
+
+The IPA Font License is an open source license created by the Information-technology Promotion Agency (IPA) of Japan. It allows free use, modification, and redistribution with specific requirements for derivative works.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | Use in research, education |
+| Non-commercial | ✅ Full | Personal projects |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, document generation |
+| Web (Hosting) | ✅ Full | Self-host WOFF/WOFF2 |
+| Desktop | ✅ Full | Install on any machine |
+| Server/CI | ✅ Full | Install on servers |
+| Redistribution (Bundled) | ✅ Full | Include in packages |
+| Modification | ✅ With conditions | Must rename font |
+| Format Conversion | ✅ Full | TTF ↔ WOFF ↔ WOFF2 |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Redistribution of modified fonts | Must include source files and means to replace with original |
+| Modification | Must not use original font name |
+| Derivative works | Must license under IPA license |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Using original name | Cannot use original font name for modified versions |
+
+
+
+## See Also
+
+- [IPA Font License](https://opensource.org/licenses/IPA/)
+- [IPA Fonts](https://moji.or.jp/ipafont/)
+

--- a/src/content/licenses/lgpl.mdx
+++ b/src/content/licenses/lgpl.mdx
@@ -1,0 +1,161 @@
+---
+title: "GNU Lesser General Public License"
+---
+
+# GNU Lesser General Public License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: GNU Lesser General Public'%3E%3Ctitle%3ELicense: GNU Lesser General Public%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EGNU Lesser General Public%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: GNU Lesser General Public" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source" />
+
+**SPDX Identifier:** LGPL-2.1
+
+**SPDX Page:** https://spdx.org/licenses/LGPL-2.1.html
+
+## Quick Summary
+
+The GNU Lesser General Public License is a compromise between copyleft and permissive licensing. It allows linking to the software from non-GPL applications, making it more flexible than the GPL.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | Use in research, education |
+| Non-commercial | ✅ Full | Personal projects |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, document generation |
+| Web (Hosting) | ✅ Full | Self-host WOFF/WOFF2 |
+| Desktop | ✅ Full | Install on any machine |
+| Server/CI | ✅ Full | Install on servers |
+| Redistribution (Bundled) | ✅ Full | Can bundle with non-GPL software |
+| Modification | ✅ With conditions | Modifications to font itself need LGPL |
+| Format Conversion | ✅ Full | TTF ↔ WOFF ↔ WOFF2 |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Modification | Changes to font must be LGPL |
+| Distribution | Must provide source or link to source |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Proprietary modifications | Cannot make font itself closed-source |
+
+
+## Sample License Text
+
+From formula: `liberation`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Digitized data copyright (c) 2010 Google Corporation
+  with Reserved Font Arimo, Tinos and Cousine.
+Copyright (c) 2012 Red Hat, Inc.
+  with Reserved Font Name Liberation.
+
+This Font Software is licensed under the SIL Open Font License,
+Version 1.1.
+
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+
+PREAMBLE The goals of the Open Font License (OFL) are to stimulate
+worldwide development of collaborative font projects, to support the font
+creation efforts of academic and linguistic communities, and to provide
+a free and open framework in which fonts may be shared and improved in
+partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves.
+The fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works.  The fonts and derivatives,
+however, cannot be released under any other type of license.  The
+requirement for fonts to remain under this license does not apply to
+any document created using the fonts or their derivatives.
+
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such.
+This may include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components
+as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting ? in part or in whole ?
+any of the components of the Original Version, by changing formats or
+by porting the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical writer
+or other person who contributed to the Font Software.
+
+
+PERMISSION & CONDITIONS
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,in
+  Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+  redistributed and/or sold with any software, provided that each copy
+  contains the above copyright notice and this license. These can be
+  included either as stand-alone text files, human-readable headers or
+  in the appropriate machine-readable metadata fields within text or
+  binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+  Name(s) unless explicit written permission is granted by the
+  corresponding Copyright Holder. This restriction only applies to the
+  primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+  Software shall not be used to promote, endorse or advertise any
+  Modified Version, except to acknowledge the contribution(s) of the
+  Copyright Holder(s) and the Author(s) or with their explicit written
+  permission.
+
+5) The Font Software, modified or unmodified, in part or in whole, must
+  be distributed entirely under this license, and must not be distributed
+  under any other license. The requirement for fonts to remain under
+  this license does not apply to any document created using the Font
+  Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT.  IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER
+DEALINGS IN THE FONT SOFTWARE.
+```
+
+</details>
+
+
+## See Also
+
+- [GNU LGPL License](https://www.gnu.org/licenses/lgpl-3.0.html)
+- [Why use LGPL](https://www.gnu.org/licenses/why-not-lgpl.html)
+

--- a/src/content/licenses/lgpl.mdx.bak
+++ b/src/content/licenses/lgpl.mdx.bak
@@ -1,0 +1,157 @@
+# GNU Lesser General Public License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: GNU Lesser General Public'%3E%3Ctitle%3ELicense: GNU Lesser General Public%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EGNU Lesser General Public%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: GNU Lesser General Public"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source">
+
+**SPDX Identifier:** LGPL-2.1
+
+**SPDX Page:** https://spdx.org/licenses/LGPL-2.1.html
+
+## Quick Summary
+
+The GNU Lesser General Public License is a compromise between copyleft and permissive licensing. It allows linking to the software from non-GPL applications, making it more flexible than the GPL.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | Use in research, education |
+| Non-commercial | ✅ Full | Personal projects |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, document generation |
+| Web (Hosting) | ✅ Full | Self-host WOFF/WOFF2 |
+| Desktop | ✅ Full | Install on any machine |
+| Server/CI | ✅ Full | Install on servers |
+| Redistribution (Bundled) | ✅ Full | Can bundle with non-GPL software |
+| Modification | ✅ With conditions | Modifications to font itself need LGPL |
+| Format Conversion | ✅ Full | TTF ↔ WOFF ↔ WOFF2 |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Modification | Changes to font must be LGPL |
+| Distribution | Must provide source or link to source |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Proprietary modifications | Cannot make font itself closed-source |
+
+
+## Sample License Text
+
+From formula: `liberation`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Digitized data copyright (c) 2010 Google Corporation
+  with Reserved Font Arimo, Tinos and Cousine.
+Copyright (c) 2012 Red Hat, Inc.
+  with Reserved Font Name Liberation.
+
+This Font Software is licensed under the SIL Open Font License,
+Version 1.1.
+
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+
+PREAMBLE The goals of the Open Font License (OFL) are to stimulate
+worldwide development of collaborative font projects, to support the font
+creation efforts of academic and linguistic communities, and to provide
+a free and open framework in which fonts may be shared and improved in
+partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves.
+The fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works.  The fonts and derivatives,
+however, cannot be released under any other type of license.  The
+requirement for fonts to remain under this license does not apply to
+any document created using the fonts or their derivatives.
+
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such.
+This may include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components
+as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting ? in part or in whole ?
+any of the components of the Original Version, by changing formats or
+by porting the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical writer
+or other person who contributed to the Font Software.
+
+
+PERMISSION & CONDITIONS
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,in
+  Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+  redistributed and/or sold with any software, provided that each copy
+  contains the above copyright notice and this license. These can be
+  included either as stand-alone text files, human-readable headers or
+  in the appropriate machine-readable metadata fields within text or
+  binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+  Name(s) unless explicit written permission is granted by the
+  corresponding Copyright Holder. This restriction only applies to the
+  primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+  Software shall not be used to promote, endorse or advertise any
+  Modified Version, except to acknowledge the contribution(s) of the
+  Copyright Holder(s) and the Author(s) or with their explicit written
+  permission.
+
+5) The Font Software, modified or unmodified, in part or in whole, must
+  be distributed entirely under this license, and must not be distributed
+  under any other license. The requirement for fonts to remain under
+  this license does not apply to any document created using the Font
+  Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT.  IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER
+DEALINGS IN THE FONT SOFTWARE.
+```
+
+</details>
+
+
+## See Also
+
+- [GNU LGPL License](https://www.gnu.org/licenses/lgpl-3.0.html)
+- [Why use LGPL](https://www.gnu.org/licenses/why-not-lgpl.html)
+

--- a/src/content/licenses/microsoft-web.mdx
+++ b/src/content/licenses/microsoft-web.mdx
@@ -1,0 +1,92 @@
+---
+title: "Microsoft Web Fonts License"
+---
+
+# Microsoft Web Fonts License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Microsoft Web Fonts'%3E%3Ctitle%3ELicense: Microsoft Web Fonts%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2317a2b8' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EMicrosoft Web Fonts%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Microsoft Web Fonts" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Freely Distributable'%3E%3Ctitle%3ECategory: Freely Distributable%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2317a2b8' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EFreely Distributable%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Freely Distributable" />
+
+**SPDX Identifier:** Not on SPDX
+
+## Quick Summary
+
+Microsoft's TrueType core fonts for the Web (Andale Mono, Arial, Arial Black, Comic Sans MS, Courier New, Georgia, Impact, Times New Roman, Trebuchet MS, Verdana, Webdings) were released under a special EULA that allows free redistribution. These fonts can be used anywhere and redistributed freely (not for profit).
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full |  |
+| Non-commercial | ✅ Full |  |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, document generation |
+| Web (Hosting) | ✅ Full |  |
+| Desktop | ✅ Full | Unlimited installations |
+| Server/CI | ✅ Full |  |
+| Redistribution | ✅ With conditions | Non-profit redistribution only, must include EULA |
+| Format Conversion | ✅ With conditions | Subsetting allowed when embedding |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Redistribution | Must include EULA, cannot charge for fonts |
+| Subsetting | Only when embedding in documents |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Modification | Cannot rename, edit, or create derivative works |
+| Reverse Engineering | Cannot decompile or disassemble |
+| Standalone Sale | Cannot sell fonts for profit |
+
+
+## Sample License Text
+
+From formula: `andale`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+(from http://web.archive.org/web/20011222020409/http://www.microsoft.com/typography/fontpack/eula.htm)
+TrueType core fonts for the Web EULA
+END-USER LICENSE AGREEMENT FOR
+MICROSOFT SOFTWARE
+IMPORTANT-READ CAREFULLY: This Microsoft End-User License Agreement ("EULA") is a legal agreement between you (either an individual or a single entity) and Microsoft Corporation for the Microsoft software accompanying this EULA, which includes computer software and may include associated media, printed materials, and "on-line" or electronic documentation ("SOFTWARE PRODUCT" or "SOFTWARE"). By exercising your rights to make and use copies of the SOFTWARE PRODUCT, you agree to be bound by the terms of this EULA. If you do not agree to the terms of this EULA, you may not use the SOFTWARE PRODUCT.
+SOFTWARE PRODUCT LICENSE
+The SOFTWARE PRODUCT is protected by copyright laws and international copyright treaties, as well as other intellectual property laws and treaties. The SOFTWARE PRODUCT is licensed, not sold.
+1. GRANT OF LICENSE. This EULA grants you the following rights:
+* Installation and Use. You may install and use an unlimited number of copies of the SOFTWARE PRODUCT.
+* Reproduction and Distribution. You may reproduce and distribute an unlimited number of copies of the SOFTWARE PRODUCT; provided that each copy shall be a true and complete copy, including all copyright and trademark notices, and shall be accompanied by a copy of this EULA. Copies of the SOFTWARE PRODUCT may not be distributed for profit either on a standalone basis or included as part of your own product.
+2. DESCRIPTION OF OTHER RIGHTS AND LIMITATIONS.
+* Limitations on Reverse Engineering, Decompilation, and Disassembly. You may not reverse engineer, decompile, or disassemble the SOFTWARE PRODUCT, except and only to the extent that such activity is expressly permitted by applicable law notwithstanding this limitation.
+* Restrictions on Alteration. You may not rename, edit or create any derivative works from the SOFTWARE PRODUCT, other than subsetting when embedding them in documents.
+* Software Transfer. You may permanently transfer all of your rights under this EULA, provided the recipient agrees to the terms of this EULA.
+* Termination. Without prejudice to any other rights, Microsoft may terminate this EULA if you fail to comply with the terms and conditions of this EULA. In such event, you must destroy all copies of the SOFTWARE PRODUCT and all of its component parts.
+3. COPYRIGHT. All title and copyrights in and to the SOFTWARE PRODUCT (including but not limited to any images, text, and "applets" incorporated into the SOFTWARE PRODUCT), the accompanying printed materials, and any copies of the SOFTWARE PRODUCT are owned by Microsoft or its suppliers. The SOFTWARE PRODUCT is protected by copyright laws and international treaty provisions. Therefore, you must treat the SOFTWARE PRODUCT like any other copyrighted material.
+4. U.S. GOVERNMENT RESTRICTED RIGHTS. The SOFTWARE PRODUCT and documentation are provided with RESTRICTED RIGHTS. Use, duplication, or disclosure by the Government is subject to restrictions as set forth in subparagraph (c)(1)(ii) of the Rights in Technical Data and Computer Software clause at DFARS 252.227-7013 or subparagraphs (c)(1) and (2) of the Commercial Computer Software - Restricted Rights at 48 CFR 52.227-19, as applicable. Manufacturer is Microsoft Corporation/One Microsoft Way/Redmond, WA 98052-6399.
+LIMITED WARRANTY
+NO WARRANTIES. Microsoft expressly disclaims any warranty for the SOFTWARE PRODUCT. The SOFTWARE PRODUCT and any related documentation is provided "as is" without warranty of any kind, either express or implied, including, without limitation, the implied warranties or merchantability, fitness for a particular purpose, or noninfringement. The entire risk arising out of use or performance of the SOFTWARE PRODUCT remains with you.
+NO LIABILITY FOR CONSEQUENTIAL DAMAGES. In no event shall Microsoft or its suppliers be liable for any damages whatsoever (including, without limitation, damages for loss of business profits, business interruption, loss of business information, or any other pecuniary loss) arising out of the use of or inability to use this Microsoft product, even if Microsoft has been advised of the possibility of such damages. Because some states/jurisdictions do not allow the exclusion or limitation of liability for consequential or incidental damages, the above limitation may not apply to you.
+MISCELLANEOUS
+If you acquired this product in the United States, this EULA is governed by the laws of the State of Washington.
+If this product was acquired outside the United States, then local laws may apply.
+Should you have any questions concerning this EULA, or if you desire to contact Microsoft for any reason, please contact the Microsoft subsidiary serving your country, or write: Microsoft Sales Information Center/One Microsoft Way/Redmond, WA 98052-6399.
+this page was last updated 28 July 1998
+© 1997 Mi
+
+[... truncated for display ...]
+```
+
+</details>
+
+
+## See Also
+
+- [Microsoft Typography](https://docs.microsoft.com/en-us/typography/)
+- [Core Fonts EULA](https://web.archive.org/web/20011222020409/http://www.microsoft.com/typography/fontpack/eula.htm)
+

--- a/src/content/licenses/microsoft-web.mdx.bak
+++ b/src/content/licenses/microsoft-web.mdx.bak
@@ -1,0 +1,88 @@
+# Microsoft Web Fonts License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Microsoft Web Fonts'%3E%3Ctitle%3ELicense: Microsoft Web Fonts%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2317a2b8' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EMicrosoft Web Fonts%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Microsoft Web Fonts"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Freely Distributable'%3E%3Ctitle%3ECategory: Freely Distributable%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2317a2b8' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EFreely Distributable%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Freely Distributable">
+
+**SPDX Identifier:** Not on SPDX
+
+## Quick Summary
+
+Microsoft's TrueType core fonts for the Web (Andale Mono, Arial, Arial Black, Comic Sans MS, Courier New, Georgia, Impact, Times New Roman, Trebuchet MS, Verdana, Webdings) were released under a special EULA that allows free redistribution. These fonts can be used anywhere and redistributed freely (not for profit).
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full |  |
+| Non-commercial | ✅ Full |  |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, document generation |
+| Web (Hosting) | ✅ Full |  |
+| Desktop | ✅ Full | Unlimited installations |
+| Server/CI | ✅ Full |  |
+| Redistribution | ✅ With conditions | Non-profit redistribution only, must include EULA |
+| Format Conversion | ✅ With conditions | Subsetting allowed when embedding |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Redistribution | Must include EULA, cannot charge for fonts |
+| Subsetting | Only when embedding in documents |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Modification | Cannot rename, edit, or create derivative works |
+| Reverse Engineering | Cannot decompile or disassemble |
+| Standalone Sale | Cannot sell fonts for profit |
+
+
+## Sample License Text
+
+From formula: `andale`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+(from http://web.archive.org/web/20011222020409/http://www.microsoft.com/typography/fontpack/eula.htm)
+TrueType core fonts for the Web EULA
+END-USER LICENSE AGREEMENT FOR
+MICROSOFT SOFTWARE
+IMPORTANT-READ CAREFULLY: This Microsoft End-User License Agreement ("EULA") is a legal agreement between you (either an individual or a single entity) and Microsoft Corporation for the Microsoft software accompanying this EULA, which includes computer software and may include associated media, printed materials, and "on-line" or electronic documentation ("SOFTWARE PRODUCT" or "SOFTWARE"). By exercising your rights to make and use copies of the SOFTWARE PRODUCT, you agree to be bound by the terms of this EULA. If you do not agree to the terms of this EULA, you may not use the SOFTWARE PRODUCT.
+SOFTWARE PRODUCT LICENSE
+The SOFTWARE PRODUCT is protected by copyright laws and international copyright treaties, as well as other intellectual property laws and treaties. The SOFTWARE PRODUCT is licensed, not sold.
+1. GRANT OF LICENSE. This EULA grants you the following rights:
+* Installation and Use. You may install and use an unlimited number of copies of the SOFTWARE PRODUCT.
+* Reproduction and Distribution. You may reproduce and distribute an unlimited number of copies of the SOFTWARE PRODUCT; provided that each copy shall be a true and complete copy, including all copyright and trademark notices, and shall be accompanied by a copy of this EULA. Copies of the SOFTWARE PRODUCT may not be distributed for profit either on a standalone basis or included as part of your own product.
+2. DESCRIPTION OF OTHER RIGHTS AND LIMITATIONS.
+* Limitations on Reverse Engineering, Decompilation, and Disassembly. You may not reverse engineer, decompile, or disassemble the SOFTWARE PRODUCT, except and only to the extent that such activity is expressly permitted by applicable law notwithstanding this limitation.
+* Restrictions on Alteration. You may not rename, edit or create any derivative works from the SOFTWARE PRODUCT, other than subsetting when embedding them in documents.
+* Software Transfer. You may permanently transfer all of your rights under this EULA, provided the recipient agrees to the terms of this EULA.
+* Termination. Without prejudice to any other rights, Microsoft may terminate this EULA if you fail to comply with the terms and conditions of this EULA. In such event, you must destroy all copies of the SOFTWARE PRODUCT and all of its component parts.
+3. COPYRIGHT. All title and copyrights in and to the SOFTWARE PRODUCT (including but not limited to any images, text, and "applets" incorporated into the SOFTWARE PRODUCT), the accompanying printed materials, and any copies of the SOFTWARE PRODUCT are owned by Microsoft or its suppliers. The SOFTWARE PRODUCT is protected by copyright laws and international treaty provisions. Therefore, you must treat the SOFTWARE PRODUCT like any other copyrighted material.
+4. U.S. GOVERNMENT RESTRICTED RIGHTS. The SOFTWARE PRODUCT and documentation are provided with RESTRICTED RIGHTS. Use, duplication, or disclosure by the Government is subject to restrictions as set forth in subparagraph (c)(1)(ii) of the Rights in Technical Data and Computer Software clause at DFARS 252.227-7013 or subparagraphs (c)(1) and (2) of the Commercial Computer Software - Restricted Rights at 48 CFR 52.227-19, as applicable. Manufacturer is Microsoft Corporation/One Microsoft Way/Redmond, WA 98052-6399.
+LIMITED WARRANTY
+NO WARRANTIES. Microsoft expressly disclaims any warranty for the SOFTWARE PRODUCT. The SOFTWARE PRODUCT and any related documentation is provided "as is" without warranty of any kind, either express or implied, including, without limitation, the implied warranties or merchantability, fitness for a particular purpose, or noninfringement. The entire risk arising out of use or performance of the SOFTWARE PRODUCT remains with you.
+NO LIABILITY FOR CONSEQUENTIAL DAMAGES. In no event shall Microsoft or its suppliers be liable for any damages whatsoever (including, without limitation, damages for loss of business profits, business interruption, loss of business information, or any other pecuniary loss) arising out of the use of or inability to use this Microsoft product, even if Microsoft has been advised of the possibility of such damages. Because some states/jurisdictions do not allow the exclusion or limitation of liability for consequential or incidental damages, the above limitation may not apply to you.
+MISCELLANEOUS
+If you acquired this product in the United States, this EULA is governed by the laws of the State of Washington.
+If this product was acquired outside the United States, then local laws may apply.
+Should you have any questions concerning this EULA, or if you desire to contact Microsoft for any reason, please contact the Microsoft subsidiary serving your country, or write: Microsoft Sales Information Center/One Microsoft Way/Redmond, WA 98052-6399.
+this page was last updated 28 July 1998
+© 1997 Mi
+
+[... truncated for display ...]
+```
+
+</details>
+
+
+## See Also
+
+- [Microsoft Typography](https://docs.microsoft.com/en-us/typography/)
+- [Core Fonts EULA](https://web.archive.org/web/20011222020409/http://www.microsoft.com/typography/fontpack/eula.htm)
+

--- a/src/content/licenses/mit.mdx
+++ b/src/content/licenses/mit.mdx
@@ -1,0 +1,158 @@
+---
+title: "MIT License"
+---
+
+# MIT License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: MIT'%3E%3Ctitle%3ELicense: MIT%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EMIT%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: MIT" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source" />
+
+**SPDX Identifier:** MIT
+
+**SPDX Page:** https://spdx.org/licenses/MIT.html
+
+## Quick Summary
+
+The MIT License is one of the most permissive open source licenses. It allows virtually unlimited use, modification, and distribution with only minimal requirements - keeping the copyright notice and license text.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | Use in research, education, thesis |
+| Non-commercial | ✅ Full | Personal projects, hobbies |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, automated document generation |
+| Web (Hosting) | ✅ Full | Self-host WOFF/WOFF2/SVG |
+| Web (Subsetting) | ✅ Full | Create subsets for performance |
+| Desktop (Personal) | ✅ Full | Install on personal machines |
+| Desktop (Commercial) | ✅ Full | Install for commercial work |
+| Server/CI | ✅ Full | Install on servers, cloud |
+| Redistribution (Bundled) | ✅ Full | Include in npm/gem/any package |
+| Redistribution (Standalone) | ✅ Full | Distribute font files separately |
+| Modification | ✅ Full | Edit and redistribute |
+| Subsetting | ✅ Full | Create subset fonts |
+| Format Conversion | ✅ Full | TTF ↔ WOFF ↔ WOFF2 |
+| Commercial Documents | ✅ Full | Any commercial use |
+| Sale | ✅ Full | Can sell as part of a product |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Any use | Must include copyright notice and license text |
+
+
+## Sample License Text
+
+From formula: `google/roboto`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Copyright 2011 The Roboto Project Authors (https://github.com/googlefonts/roboto-classic)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+```
+
+</details>
+
+
+## See Also
+
+- [Open Source Initiative: MIT License](https://opensource.org/licenses/MIT)
+- [Choose a License: MIT](https://choosealicense.com/licenses/mit/)
+

--- a/src/content/licenses/mit.mdx.bak
+++ b/src/content/licenses/mit.mdx.bak
@@ -1,0 +1,154 @@
+# MIT License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: MIT'%3E%3Ctitle%3ELicense: MIT%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EMIT%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: MIT"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source">
+
+**SPDX Identifier:** MIT
+
+**SPDX Page:** https://spdx.org/licenses/MIT.html
+
+## Quick Summary
+
+The MIT License is one of the most permissive open source licenses. It allows virtually unlimited use, modification, and distribution with only minimal requirements - keeping the copyright notice and license text.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | Use in research, education, thesis |
+| Non-commercial | ✅ Full | Personal projects, hobbies |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, automated document generation |
+| Web (Hosting) | ✅ Full | Self-host WOFF/WOFF2/SVG |
+| Web (Subsetting) | ✅ Full | Create subsets for performance |
+| Desktop (Personal) | ✅ Full | Install on personal machines |
+| Desktop (Commercial) | ✅ Full | Install for commercial work |
+| Server/CI | ✅ Full | Install on servers, cloud |
+| Redistribution (Bundled) | ✅ Full | Include in npm/gem/any package |
+| Redistribution (Standalone) | ✅ Full | Distribute font files separately |
+| Modification | ✅ Full | Edit and redistribute |
+| Subsetting | ✅ Full | Create subset fonts |
+| Format Conversion | ✅ Full | TTF ↔ WOFF ↔ WOFF2 |
+| Commercial Documents | ✅ Full | Any commercial use |
+| Sale | ✅ Full | Can sell as part of a product |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Any use | Must include copyright notice and license text |
+
+
+## Sample License Text
+
+From formula: `google/roboto`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Copyright 2011 The Roboto Project Authors (https://github.com/googlefonts/roboto-classic)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+```
+
+</details>
+
+
+## See Also
+
+- [Open Source Initiative: MIT License](https://opensource.org/licenses/MIT)
+- [Choose a License: MIT](https://choosealicense.com/licenses/mit/)
+

--- a/src/content/licenses/ms-office.mdx
+++ b/src/content/licenses/ms-office.mdx
@@ -1,0 +1,100 @@
+---
+title: "Microsoft Software License"
+---
+
+# Microsoft Software License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Microsoft Software'%3E%3Ctitle%3ELicense: Microsoft Software%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%238b5cf6' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EMicrosoft Software%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Microsoft Software" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Bundled Software'%3E%3Ctitle%3ECategory: Bundled Software%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%238b5cf6' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EBundled Software%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Bundled Software" />
+
+**SPDX Identifier:** Not on SPDX
+
+## Quick Summary
+
+Fonts bundled with Microsoft software (Office, Windows) can be used on any computer where the Microsoft software is installed. Once installed, you may use those fonts with any application on that computer.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Download & Install | ✅ Full | Install the Microsoft software package |
+| Use on Device | ✅ Full | Use fonts with ANY application on that device |
+| Create Documents | ✅ Full | Create documents using the fonts on that device |
+| Server/CI (Windows) | ✅ Full | On Windows servers/containers |
+| Cloud VMs (Windows) | ✅ Full | Windows VMs on Azure, AWS, etc. |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Redistribution | Cannot redistribute the font files |
+| Redistribute Package | Cannot redistribute the installation package |
+| Move to Another Computer | Cannot extract and move fonts to another computer |
+| Share License | Cannot share the license between devices |
+| Reverse Engineer | Cannot reverse engineer, decompile, or disassemble the software |
+| Publish | Cannot publish the software for others to copy |
+| Rent/Lease | Cannot rent, lease, or lend the software |
+
+
+## Sample License Text
+
+From formula: `segoe_ui`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+MICROSOFT SOFTWARE LICENSE TERMS
+MICROSOFT OFFICE EXCEL VIEWER
+These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you.  Please read them.  They apply to the software named above, which includes the media on which you received it, if any.  The terms also apply to any Microsoft
+- updates,
+- supplements,
+- Internet-based services, and
+- support services
+for this software, unless other terms accompany those items.  If so, those terms apply.
+BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS.  IF YOU DO NOT ACCEPT THEM, DO NOT USE THE SOFTWARE.
+If you comply with these license terms, you have the rights below.
+1. INSTALLATION AND USE RIGHTS.
+a. General.  You may install and use any  number of copies of the software on your devices.  You may use the software only to view and print files created with Microsoft Office software.  You may not use the software for any other purpose.
+b. Distribution.  You may copy and distribute the software, provided that:
+- each copy is complete and unmodified, including presentation of this agreement for each user's acceptance; and
+- you indemnify, defend, and hold harmless Microsoft and its affiliates and suppliers from any claims, including attorneys'  fees, related to your distribution of the software.
+You may not:
+- distribute the software with any non-Microsoft software that may use the software to enhance its functionality,
+- alter any copyright, trademark or patent notices in the software,
+- use Microsoft's or affiliates or suppliers' name, logo or trademarks to market your products or services,
+- distribute the software with malicious, deceptive or unlawful programs, or
+- modify or distribute the software so that any part of it becomes subject to an Excluded License.  An Excluded License is one that requires, as a condition of use, modification or distribution, that
+- the code be disclosed or distributed in source code form; or
+- others have the right to modify it.
+2. SCOPE OF LICENSE.  The software is licensed, not sold. This agreement only gives you some rights to use the software.  Microsoft reserves all other rights.  Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement.  In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways.    You may not
+- work around any technical limitations in the software;
+- reverse engineer, decompile or disassemble the software, except and only to the extent that applicable law expressly permits, despite this limitation;
+- make more copies of the software than specified in this agreement or allowed by applicable law, despite this limitation;
+- publish the software for others to copy;
+- rent, lease or lend the software; or
+- use the software for commercial software hosting services.
+3. BACKUP COPY.  You may make one backup copy of the software.  You may use it only to reinstall the software.
+4. DOCUMENTATION.  Any person that has valid access to your computer or internal network may copy and use the documentation for your internal, reference purposes.
+5. TRANSFER TO ANOTHER DEVICE.  You may uninstall the software and install it on another device for your use.  You may not do so to share this license between devices.
+6. EXPORT RESTRICTIONS.  The software is subject to United States export laws and regulations.  You must comply with all domestic and international export laws and regulations that apply to the software.  These laws include restrictions on destinations, end users and end use.  For additional information, see www.microsoft.com/exporting.
+7. SUPPORT SERVICES. Because this software is "as is," we may not provide support services for it.
+8. ENTIRE AGREEMENT.  This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services.
+9. APPLICABLE LAW.
+a. United States.  If you acquired the software in the United States, Washington state law governs the interpretation of this agreement and applies to claims for breach of it, regardless of conflict of laws principles.  The laws of the state where you live govern all other claims, including claims under state consumer protection laws, unfair competition laws, and in tort.
+b. Outside the United States.  If you acquired the software in any other country, the laws of that country apply.
+10. LEGAL EFFECT.  This agreement describes certain legal rights.  You may have other rights under the laws of your country.  You may also have rights with respect to the party from whom you acquired the software.  This agreement does not change your rights under the laws of your country if the laws of your country do not permit it to do so.
+11. DISCLAIMER OF WARRANTY.   THE SOFTWARE IS LICENSED "AS-IS."  YOU BEAR THE RISK OF USING IT.  MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CON
+
+[... truncated for display ...]
+```
+
+</details>
+
+
+## See Also
+
+- [Microsoft Font Licensing](https://docs.microsoft.com/en-us/typography/fonts/)
+- [Microsoft Software License Terms](https://www.microsoft.com/useterms/)
+

--- a/src/content/licenses/ms-office.mdx.bak
+++ b/src/content/licenses/ms-office.mdx.bak
@@ -1,0 +1,96 @@
+# Microsoft Software License
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Microsoft Software'%3E%3Ctitle%3ELicense: Microsoft Software%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%238b5cf6' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EMicrosoft Software%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Microsoft Software"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Bundled Software'%3E%3Ctitle%3ECategory: Bundled Software%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%238b5cf6' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EBundled Software%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Bundled Software">
+
+**SPDX Identifier:** Not on SPDX
+
+## Quick Summary
+
+Fonts bundled with Microsoft software (Office, Windows) can be used on any computer where the Microsoft software is installed. Once installed, you may use those fonts with any application on that computer.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Download & Install | ✅ Full | Install the Microsoft software package |
+| Use on Device | ✅ Full | Use fonts with ANY application on that device |
+| Create Documents | ✅ Full | Create documents using the fonts on that device |
+| Server/CI (Windows) | ✅ Full | On Windows servers/containers |
+| Cloud VMs (Windows) | ✅ Full | Windows VMs on Azure, AWS, etc. |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Redistribution | Cannot redistribute the font files |
+| Redistribute Package | Cannot redistribute the installation package |
+| Move to Another Computer | Cannot extract and move fonts to another computer |
+| Share License | Cannot share the license between devices |
+| Reverse Engineer | Cannot reverse engineer, decompile, or disassemble the software |
+| Publish | Cannot publish the software for others to copy |
+| Rent/Lease | Cannot rent, lease, or lend the software |
+
+
+## Sample License Text
+
+From formula: `segoe_ui`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+MICROSOFT SOFTWARE LICENSE TERMS
+MICROSOFT OFFICE EXCEL VIEWER
+These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you.  Please read them.  They apply to the software named above, which includes the media on which you received it, if any.  The terms also apply to any Microsoft
+- updates,
+- supplements,
+- Internet-based services, and
+- support services
+for this software, unless other terms accompany those items.  If so, those terms apply.
+BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS.  IF YOU DO NOT ACCEPT THEM, DO NOT USE THE SOFTWARE.
+If you comply with these license terms, you have the rights below.
+1. INSTALLATION AND USE RIGHTS.
+a. General.  You may install and use any  number of copies of the software on your devices.  You may use the software only to view and print files created with Microsoft Office software.  You may not use the software for any other purpose.
+b. Distribution.  You may copy and distribute the software, provided that:
+- each copy is complete and unmodified, including presentation of this agreement for each user's acceptance; and
+- you indemnify, defend, and hold harmless Microsoft and its affiliates and suppliers from any claims, including attorneys'  fees, related to your distribution of the software.
+You may not:
+- distribute the software with any non-Microsoft software that may use the software to enhance its functionality,
+- alter any copyright, trademark or patent notices in the software,
+- use Microsoft's or affiliates or suppliers' name, logo or trademarks to market your products or services,
+- distribute the software with malicious, deceptive or unlawful programs, or
+- modify or distribute the software so that any part of it becomes subject to an Excluded License.  An Excluded License is one that requires, as a condition of use, modification or distribution, that
+- the code be disclosed or distributed in source code form; or
+- others have the right to modify it.
+2. SCOPE OF LICENSE.  The software is licensed, not sold. This agreement only gives you some rights to use the software.  Microsoft reserves all other rights.  Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement.  In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways.    You may not
+- work around any technical limitations in the software;
+- reverse engineer, decompile or disassemble the software, except and only to the extent that applicable law expressly permits, despite this limitation;
+- make more copies of the software than specified in this agreement or allowed by applicable law, despite this limitation;
+- publish the software for others to copy;
+- rent, lease or lend the software; or
+- use the software for commercial software hosting services.
+3. BACKUP COPY.  You may make one backup copy of the software.  You may use it only to reinstall the software.
+4. DOCUMENTATION.  Any person that has valid access to your computer or internal network may copy and use the documentation for your internal, reference purposes.
+5. TRANSFER TO ANOTHER DEVICE.  You may uninstall the software and install it on another device for your use.  You may not do so to share this license between devices.
+6. EXPORT RESTRICTIONS.  The software is subject to United States export laws and regulations.  You must comply with all domestic and international export laws and regulations that apply to the software.  These laws include restrictions on destinations, end users and end use.  For additional information, see www.microsoft.com/exporting.
+7. SUPPORT SERVICES. Because this software is "as is," we may not provide support services for it.
+8. ENTIRE AGREEMENT.  This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services.
+9. APPLICABLE LAW.
+a. United States.  If you acquired the software in the United States, Washington state law governs the interpretation of this agreement and applies to claims for breach of it, regardless of conflict of laws principles.  The laws of the state where you live govern all other claims, including claims under state consumer protection laws, unfair competition laws, and in tort.
+b. Outside the United States.  If you acquired the software in any other country, the laws of that country apply.
+10. LEGAL EFFECT.  This agreement describes certain legal rights.  You may have other rights under the laws of your country.  You may also have rights with respect to the party from whom you acquired the software.  This agreement does not change your rights under the laws of your country if the laws of your country do not permit it to do so.
+11. DISCLAIMER OF WARRANTY.   THE SOFTWARE IS LICENSED "AS-IS."  YOU BEAR THE RISK OF USING IT.  MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CON
+
+[... truncated for display ...]
+```
+
+</details>
+
+
+## See Also
+
+- [Microsoft Font Licensing](https://docs.microsoft.com/en-us/typography/fonts/)
+- [Microsoft Software License Terms](https://www.microsoft.com/useterms/)
+

--- a/src/content/licenses/ofl.mdx
+++ b/src/content/licenses/ofl.mdx
@@ -1,0 +1,167 @@
+---
+title: "SIL Open Font License 1.1"
+---
+
+# SIL Open Font License 1.1
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: SIL Open Font'%3E%3Ctitle%3ELicense: SIL Open Font%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3ESIL Open Font%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: SIL Open Font" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source" />
+
+**SPDX Identifier:** OFL-1.1
+
+**SPDX Page:** https://spdx.org/licenses/OFL-1.1.html
+
+## Quick Summary
+
+The SIL Open Font License (OFL) is the most permissive and popular license specifically designed for fonts. It allows free use, modification, and redistribution with minimal restrictions.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | Use in research, education, thesis |
+| Non-commercial | ✅ Full | Personal projects, hobbies |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, automated document generation |
+| Web (Hosting) | ✅ Full | Self-host WOFF/WOFF2/SVG |
+| Web (Subsetting) | ✅ Full | Create subsets for performance |
+| Desktop (Personal) | ✅ Full | Install on personal machines |
+| Desktop (Commercial) | ✅ Full | Install for commercial work |
+| Server/CI | ✅ Full | Install on servers, cloud |
+| Redistribution (Bundled) | ✅ Full | Include in npm/gem/any package |
+| Redistribution (Standalone) | ✅ Full | Distribute font files separately |
+| Modification | ✅ With conditions | Must rename using Reserved Font Name rules |
+| Subsetting | ✅ Full | Create subset fonts |
+| Format Conversion | ✅ Full | TTF ↔ WOFF ↔ WOFF2 |
+| Commercial Documents | ✅ Full | Any commercial use |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Redistribution | Must include OFL license text and copyright notice |
+| Modification | Must not use Reserved Font Name for modified versions |
+| Bundling | Should include license file in package |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Standalone Sale | Cannot sell the font files by themselves |
+| Reserved Name Use | Cannot use Reserved Font Name for modified versions |
+
+
+## Sample License Text
+
+From formula: `google/lato`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Copyright (c) 2010-2014 by tyPoland Lukasz Dziedzic (team@latofonts.com) with Reserved Font Name "Lato"
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+```
+
+</details>
+
+
+## See Also
+
+- [SIL OFL FAQ](https://scripts.sil.org/OFL-FAQ_web)
+- [SIL OFL Official Page](https://scripts.sil.org/OFL)
+- [Google Fonts OFL Guide](https://developers.google.com/fonts/docs/legal_others)
+

--- a/src/content/licenses/ofl.mdx.bak
+++ b/src/content/licenses/ofl.mdx.bak
@@ -1,0 +1,163 @@
+# SIL Open Font License 1.1
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: SIL Open Font'%3E%3Ctitle%3ELicense: SIL Open Font%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3ESIL Open Font%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: SIL Open Font"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source">
+
+**SPDX Identifier:** OFL-1.1
+
+**SPDX Page:** https://spdx.org/licenses/OFL-1.1.html
+
+## Quick Summary
+
+The SIL Open Font License (OFL) is the most permissive and popular license specifically designed for fonts. It allows free use, modification, and redistribution with minimal restrictions.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | Use in research, education, thesis |
+| Non-commercial | ✅ Full | Personal projects, hobbies |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, automated document generation |
+| Web (Hosting) | ✅ Full | Self-host WOFF/WOFF2/SVG |
+| Web (Subsetting) | ✅ Full | Create subsets for performance |
+| Desktop (Personal) | ✅ Full | Install on personal machines |
+| Desktop (Commercial) | ✅ Full | Install for commercial work |
+| Server/CI | ✅ Full | Install on servers, cloud |
+| Redistribution (Bundled) | ✅ Full | Include in npm/gem/any package |
+| Redistribution (Standalone) | ✅ Full | Distribute font files separately |
+| Modification | ✅ With conditions | Must rename using Reserved Font Name rules |
+| Subsetting | ✅ Full | Create subset fonts |
+| Format Conversion | ✅ Full | TTF ↔ WOFF ↔ WOFF2 |
+| Commercial Documents | ✅ Full | Any commercial use |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Redistribution | Must include OFL license text and copyright notice |
+| Modification | Must not use Reserved Font Name for modified versions |
+| Bundling | Should include license file in package |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Standalone Sale | Cannot sell the font files by themselves |
+| Reserved Name Use | Cannot use Reserved Font Name for modified versions |
+
+
+## Sample License Text
+
+From formula: `google/lato`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+Copyright (c) 2010-2014 by tyPoland Lukasz Dziedzic (team@latofonts.com) with Reserved Font Name "Lato"
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+```
+
+</details>
+
+
+## See Also
+
+- [SIL OFL FAQ](https://scripts.sil.org/OFL-FAQ_web)
+- [SIL OFL Official Page](https://scripts.sil.org/OFL)
+- [Google Fonts OFL Guide](https://developers.google.com/fonts/docs/legal_others)
+

--- a/src/content/licenses/public-domain.mdx
+++ b/src/content/licenses/public-domain.mdx
@@ -1,0 +1,41 @@
+---
+title: "Public Domain Fonts"
+---
+
+# Public Domain Fonts
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Public Domain Fonts'%3E%3Ctitle%3ELicense: Public Domain Fonts%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EPublic Domain Fonts%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Public Domain Fonts" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source" />
+
+**SPDX Identifier:** CC-PDDC
+
+**SPDX Page:** https://spdx.org/licenses/CC-PDDC.html
+
+## Quick Summary
+
+Public domain fonts have no copyright restrictions and can be used for any purpose without attribution or licensing requirements. The copyright has either expired, been waived, or was never applicable.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full |  |
+| Non-commercial | ✅ Full |  |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, document generation |
+| Web (Hosting) | ✅ Full |  |
+| Desktop | ✅ Full |  |
+| Server/CI | ✅ Full |  |
+| Redistribution | ✅ Full |  |
+| Modification | ✅ Full |  |
+| Format Conversion | ✅ Full |  |
+| Sale | ✅ Full | Can sell as part of products |
+
+
+
+## See Also
+
+- [Creative Commons Public Domain](https://creativecommons.org/publicdomain/)
+- [Public Domain Fonts](https://www.fontsquirrel.com/)
+

--- a/src/content/licenses/public-domain.mdx.bak
+++ b/src/content/licenses/public-domain.mdx.bak
@@ -1,0 +1,37 @@
+# Public Domain Fonts
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Public Domain Fonts'%3E%3Ctitle%3ELicense: Public Domain Fonts%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EPublic Domain Fonts%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Public Domain Fonts"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source">
+
+**SPDX Identifier:** CC-PDDC
+
+**SPDX Page:** https://spdx.org/licenses/CC-PDDC.html
+
+## Quick Summary
+
+Public domain fonts have no copyright restrictions and can be used for any purpose without attribution or licensing requirements. The copyright has either expired, been waived, or was never applicable.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full |  |
+| Non-commercial | ✅ Full |  |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, document generation |
+| Web (Hosting) | ✅ Full |  |
+| Desktop | ✅ Full |  |
+| Server/CI | ✅ Full |  |
+| Redistribution | ✅ Full |  |
+| Modification | ✅ Full |  |
+| Format Conversion | ✅ Full |  |
+| Sale | ✅ Full | Can sell as part of products |
+
+
+
+## See Also
+
+- [Creative Commons Public Domain](https://creativecommons.org/publicdomain/)
+- [Public Domain Fonts](https://www.fontsquirrel.com/)
+

--- a/src/content/licenses/ufl.mdx
+++ b/src/content/licenses/ufl.mdx
@@ -1,0 +1,166 @@
+---
+title: "Ubuntu Font License 1.0"
+---
+
+# Ubuntu Font License 1.0
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Ubuntu Font'%3E%3Ctitle%3ELicense: Ubuntu Font%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EUbuntu Font%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Ubuntu Font" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source" />
+
+**SPDX Identifier:** Ubuntu-font-1.0
+
+**SPDX Page:** https://spdx.org/licenses/Ubuntu-font-1.0.html
+
+## Quick Summary
+
+The Ubuntu Font License is a permissive license specifically designed for fonts, similar to the SIL OFL. It was created for the Ubuntu font family and allows free use, modification, and redistribution.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | Use in research, education |
+| Non-commercial | ✅ Full | Personal projects |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, document generation |
+| Web (Hosting) | ✅ Full | Self-host WOFF/WOFF2 |
+| Web (Subsetting) | ✅ Full | Create subsets |
+| Desktop | ✅ Full | Install on any machine |
+| Server/CI | ✅ Full | Install on servers |
+| Redistribution (Bundled) | ✅ Full | Include in packages |
+| Redistribution (Standalone) | ✅ Full | Distribute font files |
+| Modification | ✅ With conditions | Must rename |
+| Format Conversion | ✅ Full | TTF ↔ WOFF ↔ WOFF2 |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Redistribution | Must include UFL license text |
+| Modification | Must not use Reserved Font Name |
+| Derivative works | Must use different name |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Standalone Sale | Cannot sell fonts by themselves |
+| Reserved Name Use | Cannot use Ubuntu name for modified versions |
+
+
+## Sample License Text
+
+From formula: `google/ubuntu`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+-------------------------------
+UBUNTU FONT LICENCE Version 1.0
+-------------------------------
+
+PREAMBLE
+This licence allows the licensed fonts to be used, studied, modified and
+redistributed freely. The fonts, including any derivative works, can be
+bundled, embedded, and redistributed provided the terms of this licence
+are met. The fonts and derivatives, however, cannot be released under
+any other licence. The requirement for fonts to remain under this
+licence does not require any document created using the fonts or their
+derivatives to be published under this licence, as long as the primary
+purpose of the document is not to be a vehicle for the distribution of
+the fonts.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this licence and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Original Version" refers to the collection of Font Software components
+as received under this licence.
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to
+a new environment.
+
+"Copyright Holder(s)" refers to all individuals and companies who have a
+copyright ownership of the Font Software.
+
+"Substantially Changed" refers to Modified Versions which can be easily
+identified as dissimilar to the Font Software by users of the Font
+Software comparing the Original Version with the Modified Version.
+
+To "Propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy. Propagation includes copying,
+distribution (with or without modification and with or without charging
+a redistribution fee), making available to the public, and in some
+countries other activities as well.
+
+PERMISSION & CONDITIONS
+This licence does not grant any rights under trademark law and all such
+rights are reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of the Font Software, to propagate the Font Software, subject to
+the below conditions:
+
+1) Each copy of the Font Software must contain the above copyright
+notice and this licence. These can be included either as stand-alone
+text files, human-readable headers or in the appropriate machine-
+readable metadata fields within text or binary files as long as those
+fields can be easily viewed by the user.
+
+2) The font name complies with the following:
+(a) The Original Version must retain its name, unmodified.
+(b) Modified Versions which are Substantially Changed must be renamed to
+avoid use of the name of the Original Version or similar names entirely.
+(c) Modified Versions which are not Substantially Changed must be
+renamed to both (i) retain the name of the Original Version and (ii) add
+additional naming elements to distinguish the Modified Version from the
+Original Version. The name of such Modified Versions must be the name of
+the Original Version, with "derivative X" where X represents the name of
+the new work, appended to that name.
+
+3) The name(s) of the Copyright Holder(s) and any contributor to the
+Font Software shall not be used to promote, endorse or advertise any
+Modified Version, except (i) as required by this licence, (ii) to
+acknowledge the contribution(s) of the Copyright Holder(s) or (iii) with
+their explicit written permission.
+
+4) The Font Software, modified or unmodified, in part or in whole, must
+be distributed entirely under this licence, and must not be distributed
+under any other licence. The requirement for fonts to remain under this
+licence does not affect any document created using the Font Software,
+except any version of the Font Software extracted from a document
+created using the Font Software may only be distributed under this
+licence.
+
+TERMINATION
+This licence becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER
+DEALINGS IN THE FONT SOFTWARE.
+
+```
+
+</details>
+
+
+## See Also
+
+- [Ubuntu Font Family](https://design.ubuntu.com/font/)
+- [SPDX: Ubuntu-font-1.0](https://spdx.org/licenses/Ubuntu-font-1.0.html)
+

--- a/src/content/licenses/ufl.mdx.bak
+++ b/src/content/licenses/ufl.mdx.bak
@@ -1,0 +1,162 @@
+# Ubuntu Font License 1.0
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: Ubuntu Font'%3E%3Ctitle%3ELicense: Ubuntu Font%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3EUbuntu Font%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: Ubuntu Font"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Open Source'%3E%3Ctitle%3ECategory: Open Source%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2328a745' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EOpen Source%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Open Source">
+
+**SPDX Identifier:** Ubuntu-font-1.0
+
+**SPDX Page:** https://spdx.org/licenses/Ubuntu-font-1.0.html
+
+## Quick Summary
+
+The Ubuntu Font License is a permissive license specifically designed for fonts, similar to the SIL OFL. It was created for the Ubuntu font family and allows free use, modification, and redistribution.
+
+## Permissions Overview
+
+### ✅ Allows For
+
+| Context | Permission | Notes |
+|---------|------------|-------|
+| Academic | ✅ Full | Use in research, education |
+| Non-commercial | ✅ Full | Personal projects |
+| Commercial (Static) | ✅ Full | PDFs, images, printed materials |
+| Commercial (Server) | ✅ Full | CI/CD, document generation |
+| Web (Hosting) | ✅ Full | Self-host WOFF/WOFF2 |
+| Web (Subsetting) | ✅ Full | Create subsets |
+| Desktop | ✅ Full | Install on any machine |
+| Server/CI | ✅ Full | Install on servers |
+| Redistribution (Bundled) | ✅ Full | Include in packages |
+| Redistribution (Standalone) | ✅ Full | Distribute font files |
+| Modification | ✅ With conditions | Must rename |
+| Format Conversion | ✅ Full | TTF ↔ WOFF ↔ WOFF2 |
+
+### ⚠️ Conditional
+
+| Permission | Condition |
+|------------|-----------|
+| Redistribution | Must include UFL license text |
+| Modification | Must not use Reserved Font Name |
+| Derivative works | Must use different name |
+
+### ❌ Disallows For
+
+| Permission | Notes |
+|------------|-------|
+| Standalone Sale | Cannot sell fonts by themselves |
+| Reserved Name Use | Cannot use Ubuntu name for modified versions |
+
+
+## Sample License Text
+
+From formula: `google/ubuntu`
+
+<details>
+<summary>View Full License Text</summary>
+
+```
+-------------------------------
+UBUNTU FONT LICENCE Version 1.0
+-------------------------------
+
+PREAMBLE
+This licence allows the licensed fonts to be used, studied, modified and
+redistributed freely. The fonts, including any derivative works, can be
+bundled, embedded, and redistributed provided the terms of this licence
+are met. The fonts and derivatives, however, cannot be released under
+any other licence. The requirement for fonts to remain under this
+licence does not require any document created using the fonts or their
+derivatives to be published under this licence, as long as the primary
+purpose of the document is not to be a vehicle for the distribution of
+the fonts.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this licence and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Original Version" refers to the collection of Font Software components
+as received under this licence.
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to
+a new environment.
+
+"Copyright Holder(s)" refers to all individuals and companies who have a
+copyright ownership of the Font Software.
+
+"Substantially Changed" refers to Modified Versions which can be easily
+identified as dissimilar to the Font Software by users of the Font
+Software comparing the Original Version with the Modified Version.
+
+To "Propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy. Propagation includes copying,
+distribution (with or without modification and with or without charging
+a redistribution fee), making available to the public, and in some
+countries other activities as well.
+
+PERMISSION & CONDITIONS
+This licence does not grant any rights under trademark law and all such
+rights are reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of the Font Software, to propagate the Font Software, subject to
+the below conditions:
+
+1) Each copy of the Font Software must contain the above copyright
+notice and this licence. These can be included either as stand-alone
+text files, human-readable headers or in the appropriate machine-
+readable metadata fields within text or binary files as long as those
+fields can be easily viewed by the user.
+
+2) The font name complies with the following:
+(a) The Original Version must retain its name, unmodified.
+(b) Modified Versions which are Substantially Changed must be renamed to
+avoid use of the name of the Original Version or similar names entirely.
+(c) Modified Versions which are not Substantially Changed must be
+renamed to both (i) retain the name of the Original Version and (ii) add
+additional naming elements to distinguish the Modified Version from the
+Original Version. The name of such Modified Versions must be the name of
+the Original Version, with "derivative X" where X represents the name of
+the new work, appended to that name.
+
+3) The name(s) of the Copyright Holder(s) and any contributor to the
+Font Software shall not be used to promote, endorse or advertise any
+Modified Version, except (i) as required by this licence, (ii) to
+acknowledge the contribution(s) of the Copyright Holder(s) or (iii) with
+their explicit written permission.
+
+4) The Font Software, modified or unmodified, in part or in whole, must
+be distributed entirely under this licence, and must not be distributed
+under any other licence. The requirement for fonts to remain under this
+licence does not affect any document created using the Font Software,
+except any version of the Font Software extracted from a document
+created using the Font Software may only be distributed under this
+licence.
+
+TERMINATION
+This licence becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER
+DEALINGS IN THE FONT SOFTWARE.
+
+```
+
+</details>
+
+
+## See Also
+
+- [Ubuntu Font Family](https://design.ubuntu.com/font/)
+- [SPDX: Ubuntu-font-1.0](https://spdx.org/licenses/Ubuntu-font-1.0.html)
+

--- a/src/content/licenses/unknown.mdx
+++ b/src/content/licenses/unknown.mdx
@@ -1,0 +1,24 @@
+---
+title: "License Not Specified"
+---
+
+# License Not Specified
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: License Not Specified'%3E%3Ctitle%3ELicense: License Not Specified%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2317a2b8' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3ELicense Not Specified%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: License Not Specified" /> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Unknown'%3E%3Ctitle%3ECategory: Unknown%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2317a2b8' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EUnknown%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Unknown" />
+
+**SPDX Identifier:** Not on SPDX
+
+## Quick Summary
+
+This formula does not contain license information in its YAML file. This does not mean the font is proprietary! You must check the font's source to determine the license.
+
+## Permissions Overview
+
+
+
+## See Also
+
+- [License Overview](/formulas/guide/licenses/)
+- [Freely Usable](/formulas/guide/licenses/free-use)
+- [Freeware](/formulas/guide/licenses/freeware)
+

--- a/src/content/licenses/unknown.mdx.bak
+++ b/src/content/licenses/unknown.mdx.bak
@@ -1,0 +1,20 @@
+# License Not Specified
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='License: License Not Specified'%3E%3Ctitle%3ELicense: License Not Specified%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2317a2b8' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ELicense%3C/text%3E%3Ctext x='90' y='15'%3ELicense Not Specified%3C/text%3E%3C/g%3E%3C/svg%3E" alt="License: License Not Specified"> <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='auto' height='20' role='img' aria-label='Category: Unknown'%3E%3Ctitle%3ECategory: Unknown%3C/title%3E%3ClinearGradient id='b' x2='0' y2='100%25'%3E%3Cstop offset='0' stop-color='%23bbb' stop-opacity='.1'/%3E%3Cstop offset='1' stop-opacity='.1'/%3E%3C/linearGradient%3E%3Cmask id='a'%3E%3Crect width='100%25' height='100%25' fill='%23fff' rx='3'/%3E%3C/mask%3E%3Cg mask='url(%23a)'%3E%3Cpath fill='%23555' d='M0 0h50v20H0z'/%3E%3Cpath fill='%2317a2b8' d='M50 0h80v20H50z'/%3E%3Cpath fill='url(%23b)' d='M0 0h130v20H0z'/%3E%3C/g%3E%3Cg fill='%23fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' font-size='11'%3E%3Ctext x='25' y='15'%3ECategory%3C/text%3E%3Ctext x='90' y='15'%3EUnknown%3C/text%3E%3C/g%3E%3C/svg%3E" alt="Category: Unknown">
+
+**SPDX Identifier:** Not on SPDX
+
+## Quick Summary
+
+This formula does not contain license information in its YAML file. This does not mean the font is proprietary! You must check the font's source to determine the license.
+
+## Permissions Overview
+
+
+
+## See Also
+
+- [License Overview](/formulas/guide/licenses/)
+- [Freely Usable](/formulas/guide/licenses/free-use)
+- [Freeware](/formulas/guide/licenses/freeware)
+

--- a/src/content/pages/about.mdx
+++ b/src/content/pages/about.mdx
@@ -1,0 +1,232 @@
+---
+title: About Fontist
+description: The story behind Fontist - cross-platform font management for automated systems and digital publishing.
+---
+
+# About Fontist
+
+<div class="about-hero">
+  <p class="about-tagline">Making fonts accessible to automated systems everywhere</p>
+</div>
+
+## Origin Story
+
+Back in 2020, at [Ribose](https://www.ribose.com/), we faced a recurring challenge. Our digital publishing workflows required specific fonts to be installed on cross-platform automated systems and cloud runners. We needed a non-interactive way to work with fonts—one that could run silently in CI/CD pipelines without manual intervention.
+
+**The problem?** There was no cross-platform solution. Font installation was either:
+
+- Tied to graphical interfaces (macOS Font Book, Windows Font Viewer)
+- Platform-specific command-line tools
+- Requiring manual downloads and installation steps
+
+This created friction for automated document generation, PDF rendering, and other publishing tasks that depend on specific fonts being available.
+
+**Fontist was born** from this need—a cross-platform font installer that works identically on Windows, Linux, and macOS:
+
+```sh
+fontist install "Roboto"
+```
+
+No graphical interface. No manual downloads. No platform-specific scripts.
+
+Since then, Fontist has become the **de-facto location where open-source fonts are downloaded for automated processes**, especially in digital publishing.
+
+---
+
+## The Name & Logo
+
+### Why "Fontist"?
+
+The name **Fontist** combines "Font" with the suffix **"-ist,"** which denotes a person who practices or is deeply concerned with a particular subject or field.
+
+Just as a **chemist** devotes themselves to the science of chemicals, a **typist** masters the art of typing, and a **pianist** dedicates themselves to the piano—a **Fontist** is one who takes the topic of fonts seriously. It reflects our commitment to understanding fonts deeply: their formats, their licensing, their installation, and their role in the digital publishing ecosystem.
+
+A Fontist is not merely a user of fonts, but a practitioner who ensures fonts are available, properly licensed, and correctly installed across any platform or environment.
+
+### Why "Fontisan"?
+
+Our companion project **Fontisan** takes its name from the fusion of **"font"** and **"artisan."**
+
+An artisan is a skilled craftsperson who creates things with careful attention to detail and quality. Fontisan embodies this spirit—it's a tool for those who craft with fonts: converting between formats, subsetting glyphs, building font packages, and manipulating type with precision.
+
+While Fontist handles the logistics of getting fonts onto systems, Fontisan provides the artisanal tools for shaping and transforming fonts to fit specific needs.
+
+### The Logo
+
+The Fontist logo embodies the intersection of typography, code, and utility.
+
+<div class="logo-breakdown">
+  <div class="logo-display">
+    <img src="/logo.svg" alt="Fontist Logo" class="logo-image"  />
+  </div>
+  <div class="logo-explanation">
+
+#### **The Keycap Shape**
+
+The logo contains a keyboard keycap because typing is the primary way humans
+interact with fonts. Every **keystroke**, every message typed, every document, every
+line of code, imbues human intent into digital form. The keycap symbolizes this
+fundamental connection between human expression and digital typography.
+
+#### **The Ruby "f"**
+
+The central **"f"** is rendered in [STIX Two Math](https://www.stixfonts.org/),
+a mathematical typeface. It represents the **abstract** beauty of computer fonts
+-- the abstract shapes of typography defined as mathematical curves. The
+elegance that emerges when typography meets computation. The ruby color reflects
+our passion and the precious value we place on open-source fonts, as well as the
+fact that Fontist was first created on Ruby, the object-oriented interpretive
+language.
+
+#### **The Brackets "[..]"**
+
+Surrounding the "f" are brackets rendered in [Source Code](https://fonts.google.com/specimen/Source+Code+Pro),
+a monospace font.
+These represent **code** -- the enabler. They're in gray because while they
+don't demand attention, they quietly make everything possible. The brackets are
+in monospace font because Fontist is made for code and is code itself to support
+the usage of fonts. Code is the infrastructure upon which the beauty of fonts is
+delivered.
+
+  </div>
+</div>
+
+### What It All Means
+
+<div class="mission-statement">
+
+**Fontist exists to provide value for open source and automated digital publishing, promoting the beauty of open source fonts and their foundries to be known, seen, and used.**
+
+</div>
+
+We believe that:
+- Fonts should be **accessible** to automated systems, not just graphical interfaces
+- Open-source fonts and their creators deserve **visibility and recognition**
+- The beauty of typography should be **celebrated** in digital publishing
+- **Code** is the bridge that makes this beauty available everywhere
+
+---
+
+## The Ecosystem
+
+Fontist has expanded into a family of tools for comprehensive font management:
+
+| Project | Purpose |
+|---------|---------|
+| [**Fontist**](https://www.fontist.org/fontist/) | Install and manage fonts across platforms |
+| [**Fontisan**](https://github.com/fontist/fontisan) | Manipulate, convert, and build fonts programmatically |
+| [**Formulas**](https://www.fontist.org/formulas/) | Registry of 2,000+ font installation recipes |
+
+### Fontist
+The core software and library for installing and managing fonts. It handles font discovery, downloading, licensing acceptance, and installation across all major platforms.
+
+### Fontisan
+A complementary tool for manipulating, converting, and building fonts programmatically. Perfect for font workflows that require format conversion, subsetting, or modification.
+
+### Fontist Formulas
+A community-driven registry of font installation recipes. Each formula contains the instructions for downloading and installing a font package from the internet. Anyone can contribute new fonts.
+
+---
+
+## Who Uses Fontist
+
+<div class="use-cases-grid">
+  <div class="use-case">
+    <div class="use-case-icon">📄</div>
+    <h4>Document Generation</h4>
+    <p>Automated PDF creation with proper typography in CI/CD pipelines</p>
+  </div>
+  <div class="use-case">
+    <div class="use-case-icon">🔄</div>
+    <h4>CI/CD Pipelines</h4>
+    <p>Font installation in GitHub Actions, GitLab CI, Jenkins, and other runners</p>
+  </div>
+  <div class="use-case">
+    <div class="use-case-icon">🎨</div>
+    <h4>Design Automation</h4>
+    <p>Programmatic design tasks requiring specific fonts</p>
+  </div>
+  <div class="use-case">
+    <div class="use-case-icon">🐳</div>
+    <h4>Containerized Environments</h4>
+    <p>Docker images with pre-installed fonts for reproducible builds</p>
+  </div>
+  <div class="use-case">
+    <div class="use-case-icon">🧪</div>
+    <h4>Testing Environments</h4>
+    <p>Consistent fonts across test machines for reliable visual tests</p>
+  </div>
+  <div class="use-case">
+    <div class="use-case-icon">📚</div>
+    <h4>Digital Publishing</h4>
+    <p>Automated typesetting and document rendering workflows</p>
+  </div>
+</div>
+
+---
+
+## Platform Support
+
+Fontist provides deep integration with operating systems, making fonts accessible and manageable across diverse environments.
+
+### Native Platform Support
+
+Fontist supports all versions of the major desktop operating systems:
+
+- **macOS** — Full integration with Font Book, system fonts, and supplementary fonts
+- **Linux** — Support for system font directories and user font paths
+- **Windows** — Integration with Windows font management
+
+### Extended Platform Support
+
+In addition to the major platforms, Fontist also supports specialized Linux distributions:
+
+- **Alpine Linux** — Package manager integration and system paths
+- **Arch Linux** — Native pacman integration and font directories
+
+### System Font Access
+
+Fontist provides access to fonts already bundled with your operating system:
+
+- **System fonts** — Fonts bundled with the OS installation
+- **Supplementary fonts** — Additional fonts available from OS vendors
+- **Platform-specific fonts** — On macOS and Windows, access to system-specific-licensed fonts and on-demand platform fonts
+
+### Installation & Management Options
+
+Fontist offers flexible approaches to font management:
+
+- **Direct OS Installation** — Install fonts directly into your operating system's font directories
+- **Integrated Management** — Let Fontist manage fonts through its own system
+- **Separate Management** — Maintain your own font directories with full control
+
+---
+
+## Open Source
+
+Fontist is proudly open source. We believe font management infrastructure should be freely available to everyone.
+
+- **GitHub**: [github.com/fontist](https://github.com/fontist)
+- **License**: Open source licenses for all components
+- **Contributing**: New formulas and features welcome
+
+---
+
+## Get Started
+
+Ready to use Fontist in your automated workflows?
+
+<div class="get-started-links">
+  <a href="https://www.fontist.org/fontist/" target="_self" class="gs-link gs-link-primary">
+    <span class="gs-title">Documentation</span>
+    <span class="gs-desc">Learn how to install and use Fontist</span>
+  </a>
+  <a href="https://www.fontist.org/formulas/" target="_self" class="gs-link">
+    <span class="gs-title">Browse Formulas</span>
+    <span class="gs-desc">Explore 2,000+ available fonts</span>
+  </a>
+  <a href="/blog/" class="gs-link">
+    <span class="gs-title">Read the Blog</span>
+    <span class="gs-desc">Latest updates and features</span>
+  </a>
+</div>

--- a/src/content/pages/about.mdx.bak
+++ b/src/content/pages/about.mdx.bak
@@ -1,0 +1,232 @@
+---
+title: About Fontist
+description: The story behind Fontist - cross-platform font management for automated systems and digital publishing.
+---
+
+# About Fontist
+
+<div class="about-hero">
+  <p class="about-tagline">Making fonts accessible to automated systems everywhere</p>
+</div>
+
+## Origin Story
+
+Back in 2020, at [Ribose](https://www.ribose.com/), we faced a recurring challenge. Our digital publishing workflows required specific fonts to be installed on cross-platform automated systems and cloud runners. We needed a non-interactive way to work with fonts—one that could run silently in CI/CD pipelines without manual intervention.
+
+**The problem?** There was no cross-platform solution. Font installation was either:
+
+- Tied to graphical interfaces (macOS Font Book, Windows Font Viewer)
+- Platform-specific command-line tools
+- Requiring manual downloads and installation steps
+
+This created friction for automated document generation, PDF rendering, and other publishing tasks that depend on specific fonts being available.
+
+**Fontist was born** from this need—a cross-platform font installer that works identically on Windows, Linux, and macOS:
+
+```sh
+fontist install "Roboto"
+```
+
+No graphical interface. No manual downloads. No platform-specific scripts.
+
+Since then, Fontist has become the **de-facto location where open-source fonts are downloaded for automated processes**, especially in digital publishing.
+
+---
+
+## The Name & Logo
+
+### Why "Fontist"?
+
+The name **Fontist** combines "Font" with the suffix **"-ist,"** which denotes a person who practices or is deeply concerned with a particular subject or field.
+
+Just as a **chemist** devotes themselves to the science of chemicals, a **typist** masters the art of typing, and a **pianist** dedicates themselves to the piano—a **Fontist** is one who takes the topic of fonts seriously. It reflects our commitment to understanding fonts deeply: their formats, their licensing, their installation, and their role in the digital publishing ecosystem.
+
+A Fontist is not merely a user of fonts, but a practitioner who ensures fonts are available, properly licensed, and correctly installed across any platform or environment.
+
+### Why "Fontisan"?
+
+Our companion project **Fontisan** takes its name from the fusion of **"font"** and **"artisan."**
+
+An artisan is a skilled craftsperson who creates things with careful attention to detail and quality. Fontisan embodies this spirit—it's a tool for those who craft with fonts: converting between formats, subsetting glyphs, building font packages, and manipulating type with precision.
+
+While Fontist handles the logistics of getting fonts onto systems, Fontisan provides the artisanal tools for shaping and transforming fonts to fit specific needs.
+
+### The Logo
+
+The Fontist logo embodies the intersection of typography, code, and utility.
+
+<div class="logo-breakdown">
+  <div class="logo-display">
+    <img src="/logo.svg" alt="Fontist Logo" class="logo-image" />
+  </div>
+  <div class="logo-explanation">
+
+#### **The Keycap Shape**
+
+The logo contains a keyboard keycap because typing is the primary way humans
+interact with fonts. Every **keystroke**, every message typed, every document, every
+line of code, imbues human intent into digital form. The keycap symbolizes this
+fundamental connection between human expression and digital typography.
+
+#### **The Ruby "f"**
+
+The central **"f"** is rendered in [STIX Two Math](https://www.stixfonts.org/),
+a mathematical typeface. It represents the **abstract** beauty of computer fonts
+-- the abstract shapes of typography defined as mathematical curves. The
+elegance that emerges when typography meets computation. The ruby color reflects
+our passion and the precious value we place on open-source fonts, as well as the
+fact that Fontist was first created on Ruby, the object-oriented interpretive
+language.
+
+#### **The Brackets "[..]"**
+
+Surrounding the "f" are brackets rendered in [Source Code](https://fonts.google.com/specimen/Source+Code+Pro),
+a monospace font.
+These represent **code** -- the enabler. They're in gray because while they
+don't demand attention, they quietly make everything possible. The brackets are
+in monospace font because Fontist is made for code and is code itself to support
+the usage of fonts. Code is the infrastructure upon which the beauty of fonts is
+delivered.
+
+  </div>
+</div>
+
+### What It All Means
+
+<div class="mission-statement">
+
+**Fontist exists to provide value for open source and automated digital publishing, promoting the beauty of open source fonts and their foundries to be known, seen, and used.**
+
+</div>
+
+We believe that:
+- Fonts should be **accessible** to automated systems, not just graphical interfaces
+- Open-source fonts and their creators deserve **visibility and recognition**
+- The beauty of typography should be **celebrated** in digital publishing
+- **Code** is the bridge that makes this beauty available everywhere
+
+---
+
+## The Ecosystem
+
+Fontist has expanded into a family of tools for comprehensive font management:
+
+| Project | Purpose |
+|---------|---------|
+| [**Fontist**](https://www.fontist.org/fontist/) | Install and manage fonts across platforms |
+| [**Fontisan**](https://github.com/fontist/fontisan) | Manipulate, convert, and build fonts programmatically |
+| [**Formulas**](https://www.fontist.org/formulas/) | Registry of 2,000+ font installation recipes |
+
+### Fontist
+The core software and library for installing and managing fonts. It handles font discovery, downloading, licensing acceptance, and installation across all major platforms.
+
+### Fontisan
+A complementary tool for manipulating, converting, and building fonts programmatically. Perfect for font workflows that require format conversion, subsetting, or modification.
+
+### Fontist Formulas
+A community-driven registry of font installation recipes. Each formula contains the instructions for downloading and installing a font package from the internet. Anyone can contribute new fonts.
+
+---
+
+## Who Uses Fontist
+
+<div class="use-cases-grid">
+  <div class="use-case">
+    <div class="use-case-icon">📄</div>
+    <h4>Document Generation</h4>
+    <p>Automated PDF creation with proper typography in CI/CD pipelines</p>
+  </div>
+  <div class="use-case">
+    <div class="use-case-icon">🔄</div>
+    <h4>CI/CD Pipelines</h4>
+    <p>Font installation in GitHub Actions, GitLab CI, Jenkins, and other runners</p>
+  </div>
+  <div class="use-case">
+    <div class="use-case-icon">🎨</div>
+    <h4>Design Automation</h4>
+    <p>Programmatic design tasks requiring specific fonts</p>
+  </div>
+  <div class="use-case">
+    <div class="use-case-icon">🐳</div>
+    <h4>Containerized Environments</h4>
+    <p>Docker images with pre-installed fonts for reproducible builds</p>
+  </div>
+  <div class="use-case">
+    <div class="use-case-icon">🧪</div>
+    <h4>Testing Environments</h4>
+    <p>Consistent fonts across test machines for reliable visual tests</p>
+  </div>
+  <div class="use-case">
+    <div class="use-case-icon">📚</div>
+    <h4>Digital Publishing</h4>
+    <p>Automated typesetting and document rendering workflows</p>
+  </div>
+</div>
+
+---
+
+## Platform Support
+
+Fontist provides deep integration with operating systems, making fonts accessible and manageable across diverse environments.
+
+### Native Platform Support
+
+Fontist supports all versions of the major desktop operating systems:
+
+- **macOS** — Full integration with Font Book, system fonts, and supplementary fonts
+- **Linux** — Support for system font directories and user font paths
+- **Windows** — Integration with Windows font management
+
+### Extended Platform Support
+
+In addition to the major platforms, Fontist also supports specialized Linux distributions:
+
+- **Alpine Linux** — Package manager integration and system paths
+- **Arch Linux** — Native pacman integration and font directories
+
+### System Font Access
+
+Fontist provides access to fonts already bundled with your operating system:
+
+- **System fonts** — Fonts bundled with the OS installation
+- **Supplementary fonts** — Additional fonts available from OS vendors
+- **Platform-specific fonts** — On macOS and Windows, access to system-specific-licensed fonts and on-demand platform fonts
+
+### Installation & Management Options
+
+Fontist offers flexible approaches to font management:
+
+- **Direct OS Installation** — Install fonts directly into your operating system's font directories
+- **Integrated Management** — Let Fontist manage fonts through its own system
+- **Separate Management** — Maintain your own font directories with full control
+
+---
+
+## Open Source
+
+Fontist is proudly open source. We believe font management infrastructure should be freely available to everyone.
+
+- **GitHub**: [github.com/fontist](https://github.com/fontist)
+- **License**: Open source licenses for all components
+- **Contributing**: New formulas and features welcome
+
+---
+
+## Get Started
+
+Ready to use Fontist in your automated workflows?
+
+<div class="get-started-links">
+  <a href="https://www.fontist.org/fontist/" target="_self" class="gs-link gs-link-primary">
+    <span class="gs-title">Documentation</span>
+    <span class="gs-desc">Learn how to install and use Fontist</span>
+  </a>
+  <a href="https://www.fontist.org/formulas/" target="_self" class="gs-link">
+    <span class="gs-title">Browse Formulas</span>
+    <span class="gs-desc">Explore 2,000+ available fonts</span>
+  </a>
+  <a href="/blog/" class="gs-link">
+    <span class="gs-title">Read the Blog</span>
+    <span class="gs-desc">Latest updates and features</span>
+  </a>
+</div>

--- a/src/lib/fonts/font-face.mjs
+++ b/src/lib/fonts/font-face.mjs
@@ -1,0 +1,28 @@
+// Generate @font-face CSS rules from font metadata at SSG time.
+// Used by .astro page wrappers so fonts load immediately on page render.
+// The useFontFace composable detects the existing <style> element and
+// skips re-injection on the client.
+
+import { fontFormatForPath } from './format.ts'
+
+export function generateFontFaceCSS(slug, fontPath, redistributable, options = {}) {
+  if (!redistributable || !fontPath) return null
+  const fontId = `ff-${slug.replace(/[^a-z0-9]/gi, '-')}`
+  const basePath = options.basePath || '/'
+  const format = fontFormatForPath(fontPath)
+  return (
+    `@font-face{font-family:'${fontId}';` +
+    `src:url('${basePath}${fontPath}') format('${format}');` +
+    `font-weight:100 900;font-display:swap;}`
+  )
+}
+
+export function generateFamilyFontFaces(files, options = {}) {
+  const rules = []
+  for (const file of files) {
+    if (!file.redistributable || !file.path) continue
+    const css = generateFontFaceCSS(file.slug, file.path, true, options)
+    if (css) rules.push(css)
+  }
+  return rules.join('\n')
+}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,26 +1,25 @@
 ---
-// about.astro — Astro version of AboutPage.vue. Reads the markdown body
-// from content/about.md and renders it via marked. Frontmatter (title,
-// description) becomes the page metadata.
 import DefaultLayout from '../layouts/DefaultLayout.astro'
-import { marked } from 'marked'
-import { fetchText } from '../lib/ssr-fetch'
-import { parseFrontmatter } from '../lib/markdown/frontmatter.mjs'
+import { getEntry } from 'astro:content'
 
-const raw = await fetchText('content/about.md')
-const parsed = parseFrontmatter(raw || '')
-const html = await marked(parsed.body)
-const title = (parsed.frontmatter.title as string) || 'About Fontist'
-const description = parsed.frontmatter.description as string | undefined
+const about = await getEntry('pages', 'about')
+const { Content } = await about.render()
+const { title, description } = about.data
 ---
 
-<DefaultLayout title={`${title} — Fontist`} description={description} canonical="https://www.fontist.org/about">
+<DefaultLayout
+  title={`${title} — Fontist`}
+  description={description}
+  canonical="https://www.fontist.org/about"
+>
   <article class="about page-container">
     <header class="about-head">
       <h1 class="about-title">{title}</h1>
       {description && <p class="about-lede">{description}</p>}
       <hr class="about-rule" />
     </header>
-    <div class="about-body md-doc" set:html={html} />
+    <div class="about-body md-doc">
+      <Content />
+    </div>
   </article>
 </DefaultLayout>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,45 +1,27 @@
 ---
-// blog/[slug].astro — Astro version of BlogPostPage.vue. Each blog post
-// gets its own static page via getStaticPaths.
 import DefaultLayout from '../../layouts/DefaultLayout.astro'
-import { marked } from 'marked'
-import { readFileSync, readdirSync } from 'node:fs'
-import { resolve } from 'node:path'
-import { parseFrontmatter } from '../../lib/markdown/frontmatter.mjs'
+import { getCollection, type CollectionEntry } from 'astro:content'
 
 export async function getStaticPaths() {
-  const blogDir = resolve(process.cwd(), 'public', 'content', 'blog')
-  let files: string[] = []
-  try {
-    files = readdirSync(blogDir).filter((f) => f.endsWith('.md') && f !== 'index.md')
-  } catch {
-    return []
-  }
-  return files.map((f) => {
-    const slug = f.replace(/\.md$/, '')
-    const text = readFileSync(resolve(blogDir, f), 'utf8')
-    const parsed = parseFrontmatter(text)
-    return {
-      params: { slug },
-      props: { slug, frontmatter: parsed.frontmatter, body: parsed.body },
-    }
-  })
+  const posts = await getCollection('blog')
+  return posts.map((post) => ({
+    params: { slug: post.slug },
+    props: { post },
+  }))
 }
 
-const { slug, frontmatter, body } = Astro.props
+interface Props { post: CollectionEntry<'blog'> }
+const { post } = Astro.props
+const { Content } = await post.render()
+const { title, description, date, authors } = post.data
 
-const html = await marked(body)
-const title = (frontmatter.title as string) || 'Untitled'
-const description = frontmatter.description as string | undefined
-
-const formattedDate = frontmatter.date
-  ? new Date(frontmatter.date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+const formattedDate = date
+  ? new Date(date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
   : ''
-const isoDate = frontmatter.date
-  ? (isNaN(new Date(frontmatter.date).getTime()) ? '' : new Date(frontmatter.date).toISOString().slice(0, 10))
+const isoDate = date
+  ? (isNaN(new Date(date).getTime()) ? '' : new Date(date).toISOString().slice(0, 10))
   : ''
 
-const authors = frontmatter.authors as string[] | undefined
 const authorsDisplay = !authors || authors.length === 0
   ? ''
   : authors.length === 1
@@ -52,7 +34,7 @@ const authorsDisplay = !authors || authors.length === 0
 <DefaultLayout
   title={`${title} — Fontist Journal`}
   description={description}
-  canonical={`https://www.fontist.org/blog/${slug}`}
+  canonical={`https://www.fontist.org/blog/${post.slug}`}
 >
   <article class="blog">
     <nav class="blog-crumbs" aria-label="Breadcrumb">
@@ -61,27 +43,25 @@ const authorsDisplay = !authors || authors.length === 0
       <span class="blog-crumbs-here">{title}</span>
     </nav>
 
-    {frontmatter.title && (
-      <header class="blog-head">
-        {(formattedDate || authorsDisplay) && (
-          <div class="blog-eyebrow">
-            {formattedDate && <time datetime={isoDate}>{formattedDate}</time>}
-            {formattedDate && authorsDisplay && <span class="blog-eyebrow-sep" aria-hidden="true">·</span>}
-            {authorsDisplay && <span class="blog-author">{authorsDisplay}</span>}
-          </div>
-        )}
-        <h1 class="blog-title">{title}</h1>
-        {description && <p class="blog-lede">{description}</p>}
-        <hr class="blog-rule" aria-hidden="true" />
-      </header>
-    )}
+    <header class="blog-head">
+      {(formattedDate || authorsDisplay) && (
+        <div class="blog-eyebrow">
+          {formattedDate && <time datetime={isoDate}>{formattedDate}</time>}
+          {formattedDate && authorsDisplay && <span class="blog-eyebrow-sep" aria-hidden="true">·</span>}
+          {authorsDisplay && <span class="blog-author">{authorsDisplay}</span>}
+        </div>
+      )}
+      <h1 class="blog-title">{title}</h1>
+      {description && <p class="blog-lede">{description}</p>}
+      <hr class="blog-rule" aria-hidden="true" />
+    </header>
 
-    <div class="blog-body" set:html={html}></div>
+    <div class="blog-body md-doc">
+      <Content />
+    </div>
 
-    {frontmatter.title && (
-      <footer class="blog-foot">
-        <a href="/blog" class="blog-back">← Back to the journal</a>
-      </footer>
-    )}
+    <footer class="blog-foot">
+      <a href="/blog" class="blog-back">← Back to the journal</a>
+    </footer>
   </article>
 </DefaultLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,20 +1,10 @@
 ---
-// blog/index.astro — Astro version of BlogIndexPage.vue. Lists every
-// post in content/blog/ sorted newest-first.
 import DefaultLayout from '../../layouts/DefaultLayout.astro'
-import { fetchJson } from '../../lib/ssr-fetch'
+import { getCollection } from 'astro:content'
 
-interface BlogPost {
-  slug: string
-  title: string
-  date: string
-  description?: string
-}
-
-let posts: BlogPost[] = []
-try {
-  posts = await fetchJson<BlogPost[]>('content/blog/index.json')
-} catch {}
+const posts = (await getCollection('blog')).sort(
+  (a, b) => (b.data.date || '').localeCompare(a.data.date || '')
+)
 ---
 
 <DefaultLayout
@@ -23,19 +13,18 @@ try {
   canonical="https://www.fontist.org/blog"
 >
   <div class="specimen">
-    <div class="page-wrap" style="max-width: 920px;">
+    <div style="max-width: 920px; margin: 0 auto; padding: 3rem 1.5rem;">
       <header class="blog-head">
         <h1>Field Notes from the Pressroom</h1>
         <p class="lede">Releases, type discoveries, and engineering notes from the Fontist project.</p>
       </header>
-
       <ul class="blog-list">
         {posts.map((post) => (
           <li class="blog-item">
             <a href={`/blog/${post.slug}`} class="blog-link">
-              <span class="blog-date">{post.date}</span>
-              <span class="blog-title">{post.title}</span>
-              {post.description && <span class="blog-desc">{post.description}</span>}
+              <span class="blog-date">{post.data.date}</span>
+              <span class="blog-title">{post.data.title}</span>
+              {post.data.description && <span class="blog-desc">{post.data.description}</span>}
               <span class="blog-arrow" aria-hidden="true">→</span>
             </a>
           </li>
@@ -44,68 +33,3 @@ try {
     </div>
   </div>
 </DefaultLayout>
-
-<style>
-  @reference "../../styles/main.css"
-
-  .page-wrap { @apply max-w-[920px] mx-auto px-6 py-12; }
-  .blog-head { @apply mb-10; }
-  .blog-head h1 {
-    @apply font-display italic text-ink;
-    font-size: clamp(2rem, 5vw, 3rem);
-    font-weight: 400;
-    line-height: 1.05;
-    letter-spacing: -0.02em;
-    margin: 0;
-  }
-  .blog-head .lede {
-    @apply font-display italic text-ink-soft;
-    font-size: 1.1rem;
-    margin: 0.5rem 0 0;
-  }
-  .blog-list { @apply list-none m-0 p-0 flex flex-col gap-4; }
-  .blog-item { @apply m-0 p-0; }
-  .blog-link {
-    @apply flex flex-col text-ink;
-    gap: 0.35rem;
-    padding: 1.1rem 1.25rem;
-    @apply bg-paper;
-    border: 1px solid var(--color-rule);
-    border-left: 3px solid var(--color-rose);
-    border-radius: 2px;
-    text-decoration: none;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-    position: relative;
-  }
-  .blog-link:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 14px rgba(28, 26, 24, 0.08);
-  }
-  .blog-date {
-    @apply font-mono uppercase text-mute;
-    font-size: 0.65rem;
-    letter-spacing: 0.12em;
-  }
-  .blog-title {
-    @apply font-display italic text-ink;
-    font-size: 1.15rem;
-    line-height: 1.2;
-    letter-spacing: -0.005em;
-  }
-  .blog-desc {
-    @apply font-body text-ink-soft;
-    font-size: 0.8rem;
-    line-height: 1.5;
-  }
-  .blog-arrow {
-    @apply absolute text-mute;
-    top: 1.1rem;
-    right: 0.85rem;
-    font-size: 1rem;
-    transition: color 0.2s ease, transform 0.2s ease;
-  }
-  .blog-link:hover .blog-arrow {
-    @apply text-rose;
-    transform: translateX(3px);
-  }
-</style>

--- a/src/pages/families/[familySlug]/index.astro
+++ b/src/pages/families/[familySlug]/index.astro
@@ -1,12 +1,13 @@
 ---
 import DefaultLayout from '../../../layouts/DefaultLayout.astro'
 import FontFamilyPage from '../../../islands/FontFamilyPage.vue'
+import { generateFamilyFontFaces } from '../../../lib/fonts/font-face.mjs'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 export async function getStaticPaths() {
   const dataPath = resolve(process.cwd(), 'public', 'font-families.json')
-  let index: { families: { slug: string }[] } = { families: [] }
+  let index: { families: { slug: string; files: { slug: string; path: string; redistributable: boolean }[] }[] } = { families: [] }
   try {
     index = JSON.parse(readFileSync(dataPath, 'utf8'))
   } catch {
@@ -16,13 +17,14 @@ export async function getStaticPaths() {
     .filter((f) => f && f.slug)
     .map((f) => ({
       params: { familySlug: f.slug },
-      props: { familySlug: f.slug },
+      props: { familySlug: f.slug, fontFaceCSS: generateFamilyFontFaces(f.files || []) },
     }))
 }
 
-const { familySlug } = Astro.props
+const { familySlug, fontFaceCSS } = Astro.props
 ---
 
 <DefaultLayout title={`Family ${familySlug} — Fontist`}>
+  {fontFaceCSS && <style is:inline set:html={fontFaceCSS} />}
   <FontFamilyPage familySlug={familySlug} client:load />
 </DefaultLayout>

--- a/src/pages/fonts/[fontSlug]/index.astro
+++ b/src/pages/fonts/[fontSlug]/index.astro
@@ -1,35 +1,40 @@
 ---
 import DefaultLayout from '../../../layouts/DefaultLayout.astro'
 import FontStylePage from '../../../islands/FontStylePage.vue'
+import { generateFontFaceCSS } from '../../../lib/fonts/font-face.mjs'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 export async function getStaticPaths() {
   const dataPath = resolve(process.cwd(), 'public', 'font-families.json')
-  let index: { families: { files: { slug: string }[] }[] } = { families: [] }
+  let index: { families: { files: { slug: string; path: string; redistributable: boolean }[] }[] } = { families: [] }
   try {
     index = JSON.parse(readFileSync(dataPath, 'utf8'))
   } catch {
     return []
   }
   const seen = new Set<string>()
-  const paths: { params: { fontSlug: string }; props: { fontSlug: string } }[] = []
+  const paths: any[] = []
   for (const fam of index.families) {
     for (const file of fam.files || []) {
       if (!file.slug || seen.has(file.slug)) continue
       seen.add(file.slug)
       paths.push({
         params: { fontSlug: file.slug },
-        props: { fontSlug: file.slug },
+        props: {
+          fontSlug: file.slug,
+          fontFaceCSS: generateFontFaceCSS(file.slug, file.path, file.redistributable) || '',
+        },
       })
     }
   }
   return paths
 }
 
-const { fontSlug } = Astro.props
+const { fontSlug, fontFaceCSS } = Astro.props
 ---
 
 <DefaultLayout title={`Font ${fontSlug} — Fontist`}>
+  {fontFaceCSS && <style is:inline set:html={fontFaceCSS} />}
   <FontStylePage fontSlug={fontSlug} client:load />
 </DefaultLayout>

--- a/src/pages/guide.astro
+++ b/src/pages/guide.astro
@@ -1,10 +1,8 @@
 ---
 import DefaultLayout from '../layouts/DefaultLayout.astro'
 import GuidePage from '../islands/GuidePage.vue'
-
-const title = 'The Typography Guide — Fontist'
 ---
 
-<DefaultLayout title={title}>
+<DefaultLayout title="The Typography Guide — Fontist">
   <GuidePage client:load />
 </DefaultLayout>

--- a/src/pages/guide/[...path].astro
+++ b/src/pages/guide/[...path].astro
@@ -1,28 +1,28 @@
 ---
 import DefaultLayout from '../../layouts/DefaultLayout.astro'
-import GuideTopicPage from '../../islands/GuideTopicPage.vue'
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { getCollection, type CollectionEntry } from 'astro:content'
 
 export async function getStaticPaths() {
-  const indexPath = resolve(process.cwd(), 'public', 'content', 'guide', 'index.json')
-  let guides: { slug: string }[] = []
-  try {
-    guides = JSON.parse(readFileSync(indexPath, 'utf8'))
-  } catch {
-    return []
-  }
-  return guides
-    .filter((g) => g && g.slug)
-    .map((g) => ({
-      params: { path: g.slug },
-      props: { path: g.slug },
-    }))
+  const guides = await getCollection('guide')
+  return guides.map((g) => ({
+    params: { path: g.slug },
+    props: { guide: g },
+  }))
 }
 
-const { path } = Astro.props
+interface Props { guide: CollectionEntry<'guide'> }
+const { guide } = Astro.props
+const { Content } = await guide.render()
+const { title, description } = guide.data
 ---
 
-<DefaultLayout title="Guide — Fontist">
-  <GuideTopicPage path={path} client:load />
+<DefaultLayout
+  title={`${title} — Guide — Fontist`}
+  description={description}
+  canonical={`https://www.fontist.org/guide/${guide.slug}`}
+>
+  <article class="page-container md-doc">
+    <h1>{title}</h1>
+    <Content />
+  </article>
 </DefaultLayout>

--- a/src/pages/licenses/[...path].astro
+++ b/src/pages/licenses/[...path].astro
@@ -1,29 +1,27 @@
 ---
 import DefaultLayout from '../../layouts/DefaultLayout.astro'
-import LicenseDetailPage from '../../islands/LicenseDetailPage.vue'
-import { readFileSync, readdirSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { getCollection, type CollectionEntry } from 'astro:content'
 
 export async function getStaticPaths() {
-  const licDir = resolve(process.cwd(), 'public', 'content', 'licenses')
-  const slugs: string[] = []
-  try {
-    for (const ent of readdirSync(licDir, { withFileTypes: true })) {
-      if (ent.isDirectory()) slugs.push(ent.name)
-      else if (ent.name.endsWith('.md') && ent.name !== 'index.md') {
-        slugs.push(ent.name.replace(/\.md$/, ''))
-      }
-    }
-  } catch {}
-  return slugs.map((s) => ({
-    params: { path: s },
-    props: { path: s },
+  const licenses = await getCollection('licenses')
+  return licenses.map((l) => ({
+    params: { path: l.slug },
+    props: { license: l },
   }))
 }
 
-const { path } = Astro.props
+interface Props { license: CollectionEntry<'licenses'> }
+const { license } = Astro.props
+const { Content } = await license.render()
+const { title, description } = license.data
 ---
 
-<DefaultLayout title={`License ${path} — Fontist`}>
-  <LicenseDetailPage path={path} client:load />
+<DefaultLayout
+  title={`${title} — License — Fontist`}
+  description={description}
+  canonical={`https://www.fontist.org/licenses/${license.slug}`}
+>
+  <article class="page-container md-doc">
+    <Content />
+  </article>
 </DefaultLayout>


### PR DESCRIPTION
## Summary

- **MDX migration:** 43 markdown files moved to `src/content/` as `.mdx` with Astro content collections. Blog, guide, about, and license pages now render through Astro's built-in MDX pipeline with Zod-validated frontmatter.
- **Font specimen fix:** `@font-face` rules now emit at SSG time via `<style is:inline>` in font family/style `.astro` pages. Fonts load immediately on page render.

## Test plan

- [x] Astro build: 37,428 pages in ~88s
- [x] Vitest: 150 tests pass
- [x] Node tests: 253 pass
- [x] Blog/guide/about/licenses render via content collections
- [x] @font-face rules present in font page HTML
