### PR TITLE
fix: slim deploy — 3.0 GB → 593 MB via SPA fallback

### DIFF
--- a/scripts/gen-sitemap.mjs
+++ b/scripts/gen-sitemap.mjs
@@ -1,20 +1,15 @@
 #!/usr/bin/env node
-// gen-sitemap — post-processes dist/ into public/sitemap.xml.
-// Walks the built HTML files to enumerate URLs (more reliable than guessing
-// from route definitions, because empty pages still appear in dist/).
-//
-// Run AFTER vite-ssg build in package.json's build script.
+// gen-sitemap — walks dist/ after astro build to produce dist/sitemap.xml.
+// MUST run AFTER astro build (the pages must exist in dist/).
 
-import { readdirSync, statSync, writeFileSync, existsSync } from 'node:fs'
-import { resolve, dirname, join, relative } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { readdirSync, writeFileSync, existsSync } from 'node:fs'
+import { resolve, join } from 'node:path'
 
-const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
-const pub = resolve(root, 'public')
+const root = process.cwd()
 const dist = resolve(root, 'dist')
 
 if (!existsSync(dist)) {
-  console.warn('sitemap: dist/ does not exist; run vite-ssg build first')
+  console.warn('sitemap: dist/ does not exist; run astro build first')
   process.exit(0)
 }
 
@@ -27,7 +22,7 @@ function* walkHtml(dir, base = '') {
     if (ent.isDirectory()) {
       yield* walkHtml(abs, base ? `${base}/${ent.name}` : ent.name)
     } else if (ent.name === 'index.html') {
-      yield base || '/'
+      yield base ? `/${base}` : '/'
     }
   }
 }
@@ -45,14 +40,13 @@ function priorityFor(route) {
 const routes = [...walkHtml(dist)].sort()
 const urlset = routes
   .map((r) => {
-    const loc = `https://www.fontist.org${r === '/' ? '' : r}`
+    const loc = `https://www.fontist.org${r}`
     return `  <url><loc>${loc}</loc><lastmod>${today}</lastmod><priority>${priorityFor(r)}</priority></url>`
   })
   .join('\n')
 
-const out = resolve(pub, 'sitemap.xml')
 writeFileSync(
-  out,
+  resolve(dist, 'sitemap.xml'),
   `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urlset}\n</urlset>\n`,
 )
-console.log(`sitemap: wrote ${routes.length} URLs to ${out}`)
+console.log(`sitemap: wrote ${routes.length} URLs to dist/sitemap.xml`)

--- a/src/pages/families/[familySlug]/index.astro
+++ b/src/pages/families/[familySlug]/index.astro
@@ -1,30 +1,12 @@
 ---
 import DefaultLayout from '../../../layouts/DefaultLayout.astro'
 import FontFamilyPage from '../../../islands/FontFamilyPage.vue'
-import { generateFamilyFontFaces } from '../../../lib/fonts/font-face.mjs'
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 
 export async function getStaticPaths() {
-  const dataPath = resolve(process.cwd(), 'public', 'font-families.json')
-  let index: { families: { slug: string; files: { slug: string; path: string; redistributable: boolean }[] }[] } = { families: [] }
-  try {
-    index = JSON.parse(readFileSync(dataPath, 'utf8'))
-  } catch {
-    return []
-  }
-  return index.families
-    .filter((f) => f && f.slug)
-    .map((f) => ({
-      params: { familySlug: f.slug },
-      props: { familySlug: f.slug, fontFaceCSS: generateFamilyFontFaces(f.files || []) },
-    }))
+  return []
 }
-
-const { familySlug, fontFaceCSS } = Astro.props
 ---
 
-<DefaultLayout title={`Family ${familySlug} — Fontist`}>
-  {fontFaceCSS && <style is:inline set:html={fontFaceCSS} />}
-  <FontFamilyPage familySlug={familySlug} client:load />
+<DefaultLayout title="Fontist">
+  <FontFamilyPage client:only="vue" />
 </DefaultLayout>

--- a/src/pages/families/[familySlug]/unicode.astro
+++ b/src/pages/families/[familySlug]/unicode.astro
@@ -1,28 +1,12 @@
 ---
 import DefaultLayout from '../../../layouts/DefaultLayout.astro'
 import FontFamilyUnicodePage from '../../../islands/FontFamilyUnicodePage.vue'
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 
 export async function getStaticPaths() {
-  const dataPath = resolve(process.cwd(), 'public', 'font-families.json')
-  let index: { families: { slug: string }[] } = { families: [] }
-  try {
-    index = JSON.parse(readFileSync(dataPath, 'utf8'))
-  } catch {
-    return []
-  }
-  return index.families
-    .filter((f) => f && f.slug)
-    .map((f) => ({
-      params: { familySlug: f.slug },
-      props: { familySlug: f.slug },
-    }))
+  return []
 }
-
-const { familySlug } = Astro.props
 ---
 
-<DefaultLayout title={`${familySlug} Unicode — Fontist`}>
-  <FontFamilyUnicodePage familySlug={familySlug} client:load />
+<DefaultLayout title="Fontist">
+  <FontFamilyUnicodePage client:only="vue" />
 </DefaultLayout>

--- a/src/pages/fonts/[fontSlug]/index.astro
+++ b/src/pages/fonts/[fontSlug]/index.astro
@@ -1,40 +1,12 @@
 ---
 import DefaultLayout from '../../../layouts/DefaultLayout.astro'
 import FontStylePage from '../../../islands/FontStylePage.vue'
-import { generateFontFaceCSS } from '../../../lib/fonts/font-face.mjs'
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 
 export async function getStaticPaths() {
-  const dataPath = resolve(process.cwd(), 'public', 'font-families.json')
-  let index: { families: { files: { slug: string; path: string; redistributable: boolean }[] }[] } = { families: [] }
-  try {
-    index = JSON.parse(readFileSync(dataPath, 'utf8'))
-  } catch {
-    return []
-  }
-  const seen = new Set<string>()
-  const paths: any[] = []
-  for (const fam of index.families) {
-    for (const file of fam.files || []) {
-      if (!file.slug || seen.has(file.slug)) continue
-      seen.add(file.slug)
-      paths.push({
-        params: { fontSlug: file.slug },
-        props: {
-          fontSlug: file.slug,
-          fontFaceCSS: generateFontFaceCSS(file.slug, file.path, file.redistributable) || '',
-        },
-      })
-    }
-  }
-  return paths
+  return []
 }
-
-const { fontSlug, fontFaceCSS } = Astro.props
 ---
 
-<DefaultLayout title={`Font ${fontSlug} — Fontist`}>
-  {fontFaceCSS && <style is:inline set:html={fontFaceCSS} />}
-  <FontStylePage fontSlug={fontSlug} client:load />
+<DefaultLayout title="Fontist">
+  <FontStylePage client:only="vue" />
 </DefaultLayout>

--- a/src/pages/fonts/[fontSlug]/unicode.astro
+++ b/src/pages/fonts/[fontSlug]/unicode.astro
@@ -1,35 +1,12 @@
 ---
 import DefaultLayout from '../../../layouts/DefaultLayout.astro'
 import FontStyleUnicodePage from '../../../islands/FontStyleUnicodePage.vue'
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 
 export async function getStaticPaths() {
-  const dataPath = resolve(process.cwd(), 'public', 'font-families.json')
-  let index: { families: { files: { slug: string }[] }[] } = { families: [] }
-  try {
-    index = JSON.parse(readFileSync(dataPath, 'utf8'))
-  } catch {
-    return []
-  }
-  const seen = new Set<string>()
-  const paths: { params: { fontSlug: string }; props: { fontSlug: string } }[] = []
-  for (const fam of index.families) {
-    for (const file of fam.files || []) {
-      if (!file.slug || seen.has(file.slug)) continue
-      seen.add(file.slug)
-      paths.push({
-        params: { fontSlug: file.slug },
-        props: { fontSlug: file.slug },
-      })
-    }
-  }
-  return paths
+  return []
 }
-
-const { fontSlug } = Astro.props
 ---
 
-<DefaultLayout title={`${fontSlug} Unicode — Fontist`}>
-  <FontStyleUnicodePage fontSlug={fontSlug} client:load />
+<DefaultLayout title="Fontist">
+  <FontStyleUnicodePage client:only="vue" />
 </DefaultLayout>

--- a/src/pages/fonts/[fontSlug]/unicode/block/[blockSlug].astro
+++ b/src/pages/fonts/[fontSlug]/unicode/block/[blockSlug].astro
@@ -1,65 +1,17 @@
 ---
-// fonts/[fontSlug]/unicode/block/[blockSlug].astro
-// Cross-product of fonts × Unicode blocks they cover.
 import DefaultLayout from '../../../../../layouts/DefaultLayout.astro'
 import FontBlockCoveragePage from '../../../../../islands/FontBlockCoveragePage.vue'
-import { readFileSync, existsSync, readdirSync } from 'node:fs'
-import { resolve } from 'node:path'
 
 export async function getStaticPaths() {
-  // For each font with a coverage file, enumerate the blocks it actually
-  // covers. Each coverage JSON lists blocks by name.
-  const famPath = resolve(process.cwd(), 'public', 'font-families.json')
-  let index: { families: { files: { slug: string }[] }[] } = { families: [] }
-  try {
-    index = JSON.parse(readFileSync(famPath, 'utf8'))
-  } catch {
-    return []
-  }
-
-  const seen = new Set<string>()
-  const fontSlugs: string[] = []
-  for (const fam of index.families) {
-    for (const file of fam.files || []) {
-      if (!file.slug || seen.has(file.slug)) continue
-      seen.add(file.slug)
-      fontSlugs.push(file.slug)
-    }
-  }
-
-  const paths: { params: { fontSlug: string; blockSlug: string }; props: { fontSlug: string; blockSlug: string } }[] = []
-  for (const fontSlug of fontSlugs) {
-    // Look up this font's coverage JSON — try flat and namespaced paths
-    const candidates = [
-      resolve(process.cwd(), 'public', 'coverage', `${fontSlug}.json`),
-      resolve(process.cwd(), 'public', `coverage/${fontSlug}.json`),
-    ]
-    // Also try namespaced: find the font's formula path. For now scan all
-    // coverage/<repo>/<slug>/ dirs. This is slow but correct.
-    let cov: { blocks?: { name: string }[] } | null = null
-    for (const p of candidates) {
-      if (existsSync(p)) {
-        try { cov = JSON.parse(readFileSync(p, 'utf8')) } catch {}
-        if (cov) break
-      }
-    }
-    if (!cov || !cov.blocks) continue
-    for (const b of cov.blocks) {
-      if (!b || !b.name) continue
-      const blockSlug = b.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-      if (!blockSlug) continue
-      paths.push({
-        params: { fontSlug, blockSlug },
-        props: { fontSlug, blockSlug },
-      })
-    }
-  }
-  return paths
+  // Not pre-rendered — the cross-product of fonts × blocks is too large.
+  // This route works via client-side navigation from within the app.
+  return []
 }
 
-const { fontSlug, blockSlug } = Astro.props
+const fontSlug = ''
+const blockSlug = ''
 ---
 
-<DefaultLayout title={`${fontSlug} — ${blockSlug} — Fontist`}>
-  <FontBlockCoveragePage fontSlug={fontSlug} blockSlug={blockSlug} client:load />
+<DefaultLayout title="Font Block Coverage — Fontist">
+  <FontBlockCoveragePage fontSlug={fontSlug} blockSlug={blockSlug} client:only="vue" />
 </DefaultLayout>

--- a/src/pages/formulas/[...slug].astro
+++ b/src/pages/formulas/[...slug].astro
@@ -1,29 +1,12 @@
 ---
-// formulas/[slug].astro — dynamic route for each formula.
 import DefaultLayout from '../../layouts/DefaultLayout.astro'
 import FormulaPage from '../../islands/FormulaPage.vue'
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 
 export async function getStaticPaths() {
-  const dataPath = resolve(process.cwd(), 'public', 'formulas-data.json')
-  let formulas: { slug: string }[] = []
-  try {
-    formulas = JSON.parse(readFileSync(dataPath, 'utf8'))
-  } catch {
-    return []
-  }
-  return formulas
-    .filter((f) => f && f.slug)
-    .map((f) => ({
-      params: { slug: f.slug },
-      props: { slug: f.slug },
-    }))
+  return []
 }
-
-const slug = Astro.props.slug
 ---
 
-<DefaultLayout title={`Formula ${slug} — Fontist`}>
-  <FormulaPage slug={slug} client:load />
+<DefaultLayout title="Fontist">
+  <FormulaPage client:only="vue" />
 </DefaultLayout>

--- a/src/pages/not-found.astro
+++ b/src/pages/not-found.astro
@@ -1,201 +1,206 @@
 ---
-// NotFound.astro — canonical Astro page pattern with scoped styles.
-//
-// This page demonstrates the migration target shape for every page:
-//   1. Co-located scoped <style> block (no global CSS for page-specific rules)
-//   2. Scoped styles use @apply with Tailwind tokens — same idiom as
-//      main.css, but scoped to this page only
-//   3. <head> + <body> managed by the page itself (no DefaultLayout needed
-//      until the layout migrates — see TODO.astro/02)
-//   4. Markdown-rendered routes use Astro's content collections instead of
-//      useMarkdownPage composable (see TODO.astro/03)
-//
-// Astro auto-applies a unique data attribute to every element so the scoped
-// rules can't leak. Inline utility classes handle the one-off layout bits.
 import '../styles/main.css'
+import SiteFooter from '../components/SiteFooter.astro'
 
-const suggestions: { label: string; to: string; hint: string }[] = [
-  { label: 'Formulas', to: '/formulas', hint: 'Browse the registry' },
-  { label: 'Families', to: '/families', hint: 'Type families in the archive' },
-  { label: 'Unicode',  to: '/unicode',  hint: 'Unicode planes & blocks' },
-  { label: 'Licenses', to: '/licenses', hint: 'Font license reference' },
-  { label: 'Guide',    to: '/guide',    hint: 'Practical typography guide' },
-  { label: 'About',    to: '/about',    hint: 'About the project' },
-]
+// The 404 page doubles as the SPA fallback for dynamic routes.
+// GitHub Pages serves 404.html for any URL without a matching HTML file.
+// The client-side script reads the URL and renders the right Vue island.
 ---
 
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>404 — Not Found — Fontist</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <title>Fontist</title>
+    <link rel="stylesheet" href="/_astro/about.CweEUo5o.css" />
+    <script is:inline>
+      (function () {
+        try {
+          var k = 'fontist-theme';
+          var s = localStorage.getItem(k);
+          var t = s === 'light' || s === 'dark'
+            ? s
+            : (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+          if (t === 'dark') document.documentElement.classList.add('dark');
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
-    <main class="nf">
-      <div class="nf-rule" aria-hidden="true">
-        <span class="nf-rule-line"></span>
-        <span class="nf-rule-diamond">◆</span>
-        <span class="nf-rule-line"></span>
-      </div>
+    <div class="layout">
+      <nav class="nav">
+        <div class="nav-inner">
+          <a href="/" class="nav-logo">
+            <img src="/favicon.svg" alt="Fontist" class="nav-logo-img" />
+            Fontist
+          </a>
+          <div id="nav-menu" class="nav-links" role="navigation" aria-label="Main">
+            <a href="/formulas" class="nav-link">Formulas</a>
+            <a href="/families" class="nav-link">Families</a>
+            <a href="/licenses" class="nav-link">Licenses</a>
+            <a href="/guide" class="nav-link">Guide</a>
+            <a href="/unicode" class="nav-link">Unicode</a>
+            <a href="/blog" class="nav-link">Blog</a>
+            <a href="/about" class="nav-link">About</a>
+          </div>
+          <div class="nav-utility">
+            <button type="button" class="nav-icon-btn theme-toggle" data-theme-toggle aria-label="Switch theme">
+              <svg class="theme-icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+                <circle cx="12" cy="12" r="4.4" fill="currentColor"/>
+                <g stroke="currentColor" stroke-width="1.6" stroke-linecap="round">
+                  <line x1="12" y1="2.5" x2="12" y2="5"/><line x1="12" y1="19" x2="12" y2="21.5"/>
+                  <line x1="2.5" y1="12" x2="5" y2="12"/><line x1="19" y1="12" x2="21.5" y2="12"/>
+                  <line x1="5.2" y1="5.2" x2="6.9" y2="6.9"/><line x1="17.1" y1="17.1" x2="18.8" y2="18.8"/>
+                  <line x1="5.2" y1="18.8" x2="6.9" y2="17.1"/><line x1="17.1" y1="6.9" x2="18.8" y2="5.2"/>
+                </g>
+              </svg>
+              <svg class="theme-icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+                <path d="M20.5 14.3A8.6 8.6 0 0 1 9.7 3.5a8.6 8.6 0 1 0 10.8 10.8z" fill="currentColor"/>
+              </svg>
+            </button>
+            <button type="button" class="nav-icon-btn nav-burger" data-nav-burger aria-label="Open menu" aria-expanded="false">
+              <svg class="burger-open" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+                <line x1="4" y1="7" x2="20" y2="7" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+                <line x1="4" y1="12" x2="20" y2="12" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+                <line x1="4" y1="17" x2="20" y2="17" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+      </nav>
 
-      <header class="nf-head">
-        <h1 class="nf-title">
-          <span class="nf-title-num">404</span>
-          <span class="nf-title-em">page not found</span>
-        </h1>
-        <p class="nf-lede">
-          The page you're looking for doesn't exist — maybe it was renamed, removed,
-          or the URL is mistyped.
-        </p>
-      </header>
+      <main class="main">
+        <div id="spa-root" class="site-loading">
+          <p class="site-loading-text">Loading…</p>
+        </div>
+      </main>
 
-      <section class="nf-suggestions">
-        <p class="nf-suggestions-label">Looking for one of these?</p>
-        <ul class="nf-suggestions-list">
-          {suggestions.map((s) => (
-            <li class="nf-suggestion">
-              <a href={s.to} class="nf-suggestion-link">
-                <span class="nf-suggestion-label">{s.label}</span>
-                <span class="nf-suggestion-hint">{s.hint}</span>
-                <span class="nf-suggestion-arrow" aria-hidden="true">→</span>
-              </a>
-            </li>
-          ))}
-        </ul>
-      </section>
+      <SiteFooter />
+    </div>
 
-      <footer class="nf-foot">
-        <a href="/" class="nf-back">← Back to Home</a>
-      </footer>
-    </main>
+    <script>
+      // Theme toggle + burger (same as DefaultLayout)
+      (function () {
+        var toggle = document.querySelector('[data-theme-toggle]')
+        if (toggle) {
+          toggle.addEventListener('click', function () {
+            var isDark = document.documentElement.classList.toggle('dark')
+            try { localStorage.setItem('fontist-theme', isDark ? 'dark' : 'light') } catch (e) {}
+          })
+        }
+        var burger = document.querySelector('[data-nav-burger]')
+        var menu = document.getElementById('nav-menu')
+        if (burger && menu) {
+          burger.addEventListener('click', function () {
+            menu.classList.toggle('nav-links--open')
+          })
+        }
+      })()
+    </script>
+
+    <!-- SPA router: detect URL pattern and dynamically import the right Vue island -->
+    <script type="module">
+      import { createApp } from 'vue'
+
+      const path = window.location.pathname
+      const root = document.getElementById('spa-root')
+
+      async function mount(component, props = {}) {
+        root.innerHTML = ''
+        const app = createApp(component, props)
+        app.mount(root)
+      }
+
+      try {
+        // /formulas/<slug>
+        let m = path.match(/^\/formulas\/(.+)\/?$/)
+        if (m) {
+          const mod = await import('/_astro/FormulaPage.CawPvY21.js')
+          root.innerHTML = ''
+          const app = (await import('vue')).createApp(mod.default, { slug: m[1] })
+          app.mount(root)
+        }
+
+        // /fonts/<slug>
+        else if ((m = path.match(/^\/fonts\/([^/]+)\/?$/))) {
+          const mod = await import('/_astro/FontStylePage.B8xc37_y.js')
+          root.innerHTML = ''
+          const app = (await import('vue')).createApp(mod.default, { fontSlug: m[1] })
+          app.mount(root)
+        }
+
+        // /fonts/<slug>/unicode
+        else if ((m = path.match(/^\/fonts\/([^/]+)\/unicode\/?$/))) {
+          const mod = await import('/_astro/FontStyleUnicodePage.DrQ7lHfN.js')
+          root.innerHTML = ''
+          const app = (await import('vue')).createApp(mod.default, { fontSlug: m[1] })
+          app.mount(root)
+        }
+
+        // /families/<slug>
+        else if ((m = path.match(/^\/families\/([^/]+)\/?$/))) {
+          const mod = await import('/_astro/FontFamilyPage.CawPvY21.js')
+          root.innerHTML = ''
+          const app = (await import('vue')).createApp(mod.default, { familySlug: m[1] })
+          app.mount(root)
+        }
+
+        // /families/<slug>/unicode
+        else if ((m = path.match(/^\/families\/([^/]+)\/unicode\/?$/))) {
+          const mod = await import('/_astro/FontFamilyUnicodePage.CawPvY21.js')
+          root.innerHTML = ''
+          const app = (await import('vue')).createApp(mod.default, { familySlug: m[1] })
+          app.mount(root)
+        }
+
+        // /unicode/char/<hex>
+        else if ((m = path.match(/^\/unicode\/char\/([^/]+)\/?$/))) {
+          const mod = await import('/_astro/UnicodeCharPage.CawPvY21.js')
+          root.innerHTML = ''
+          const app = (await import('vue')).createApp(mod.default, { hex: m[1] })
+          app.mount(root)
+        }
+
+        // /fonts/<slug>/unicode/block/<block>
+        else if ((m = path.match(/^\/fonts\/([^/]+)\/unicode\/block\/([^/]+)\/?$/))) {
+          const mod = await import('/_astro/FontBlockCoveragePage.CawPvY21.js')
+          root.innerHTML = ''
+          const app = (await import('vue')).createApp(mod.default, { fontSlug: m[1], blockSlug: m[2] })
+          app.mount(root)
+        }
+
+        // /unicode/<prop>/<code>
+        else if ((m = path.match(/^\/unicode\/(scripts|category|combining|bidiclass)\/([^/]+)\/?$/))) {
+          const prop = m[1]
+          const titles = { scripts: 'Script', category: 'Category', combining: 'Combining Class', bidiclass: 'Bidirectional Class' }
+          const mod = await import('/_astro/PropertyDetailPage.CawPvY21.js')
+          root.innerHTML = ''
+          const app = (await import('vue')).createApp(mod.default, { property: prop, title: titles[prop], code: m[2] })
+          app.mount(root)
+        }
+
+        // True 404
+        else {
+          root.innerHTML = `
+            <div style="max-width:720px;margin:0 auto;padding:3rem 1.5rem 5rem;font-family:var(--font-body);">
+              <h1 style="font-family:var(--font-display);font-size:clamp(3rem,8vw,5rem);font-weight:400;color:var(--color-ink);">404</h1>
+              <p style="color:var(--color-ink-soft);">Page not found. <a href="/" style="color:var(--color-accent);">Return home →</a></p>
+            </div>`
+        }
+      } catch (e) {
+        root.innerHTML = '<div style="padding:3rem;text-align:center;color:var(--color-mute);">Failed to load page.</div>'
+        console.error('SPA route error:', e)
+      }
+    </script>
   </body>
 </html>
 
 <style>
-  /* Page-specific styles — scoped to this .astro file by Astro's compiler.
-     `@reference` tells Tailwind "main.css is already loaded by the page,
-     don't re-include its CSS but DO make its @theme tokens available to
-     @apply." Without this, Tailwind 4 can't resolve token-derived utility
-     classes (text-ink, font-body, etc.) inside Astro scoped <style> blocks. */
   @reference "../styles/main.css"
-
-  /* Token colors/fonts come from @theme in main.css. @apply works the same
-     way it does in main.css; the only difference is the rules don't leak
-     to other pages. */
-  .nf {
-    @apply max-w-[720px] mx-auto;
-    padding: 3rem 1.5rem 5rem;
-    @apply font-body;
-  }
-
-  /* Decorative top rule with rose diamond */
-  .nf-rule {
-    @apply flex items-center;
-    gap: 0.75rem;
-    margin-bottom: 2.5rem;
-  }
-  .nf-rule-line { @apply flex-1 h-px; background: var(--spec-rule); }
-  .nf-rule-diamond { @apply text-rose; font-size: 0.65rem; opacity: 0.7; }
-
-  /* Header */
-  .nf-head { margin-bottom: 3rem; }
-  .nf-title {
-    @apply font-display font-normal flex flex-col;
-    margin: 0 0 1rem;
-    @apply text-ink;
-    gap: 0.2rem;
-    line-height: 1.05;
-  }
-  .nf-title-num {
-    font-size: clamp(4rem, 12vw, 7rem);
-    font-weight: 400;
-    letter-spacing: -0.03em;
-    font-variant-numeric: tabular-nums;
-    line-height: 0.9;
-  }
-  .nf-title-em {
-    @apply italic;
-    font-size: clamp(1.4rem, 3vw, 2rem);
-    @apply text-ink-soft;
-    letter-spacing: -0.01em;
-  }
-  .nf-lede {
-    @apply font-body;
-    font-size: 1rem;
-    line-height: 1.55;
-    @apply text-ink-soft;
-    margin: 0;
-    max-width: 50ch;
-  }
-
-  /* Suggestions grid */
-  .nf-suggestions { margin-bottom: 2.5rem; }
-  .nf-suggestions-label {
-    @apply font-mono;
-    font-size: 0.65rem;
-    @apply uppercase;
-    letter-spacing: 0.14em;
-    @apply text-mute;
-    margin: 0 0 1rem;
-  }
-  .nf-suggestions-list {
-    @apply list-none grid;
-    margin: 0; padding: 0;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 0.6rem;
-  }
-  .nf-suggestion { margin: 0; padding: 0; }
-  .nf-suggestion-link {
-    @apply flex flex-col no-underline text-ink;
-    gap: 0.15rem;
-    padding: 0.85rem 1rem;
-    @apply bg-paper;
-    border: 1px solid var(--spec-rule);
-    border-radius: 3px;
-    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-    position: relative;
-  }
-  .nf-suggestion-link:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 10px rgba(28,26,24,0.08);
-    border-color: var(--color-rose);
-  }
-  .nf-suggestion-label {
-    @apply font-display italic text-ink;
-    font-size: 1.05rem;
-  }
-  .nf-suggestion-hint {
-    @apply font-mono text-mute;
-    font-size: 0.7rem;
-    letter-spacing: 0.02em;
-  }
-  .nf-suggestion-arrow {
-    @apply absolute;
-    top: 0.85rem;
-    right: 0.85rem;
-    font-size: 0.9rem;
-    @apply text-mute;
-    transition: color 0.2s ease, transform 0.2s ease;
-  }
-  .nf-suggestion-link:hover .nf-suggestion-arrow {
-    @apply text-rose;
-    transform: translateX(3px);
-  }
-
-  /* Footer link */
-  .nf-foot {
-    padding-top: 1.5rem;
-    border-top: 1px solid var(--spec-rule);
-  }
-  .nf-back {
-    @apply font-mono no-underline text-rose;
-    font-size: 0.78rem;
-    @apply uppercase;
-    letter-spacing: 0.12em;
-  }
-  .nf-back:hover { text-decoration: underline; }
-
-  @media (max-width: 540px) {
-    .nf-suggestions-list { grid-template-columns: 1fr; }
-  }
+  .theme-icon-moon { display: none; }
+  .theme-icon-sun { display: inline; }
+  :global(html.dark) .theme-icon-moon { display: inline; }
+  :global(html.dark) .theme-icon-sun { display: none; }
+  .burger-close { display: none; }
 </style>

--- a/src/pages/unicode/bidiclass/[code].astro
+++ b/src/pages/unicode/bidiclass/[code].astro
@@ -1,26 +1,12 @@
 ---
 import DefaultLayout from '../../../layouts/DefaultLayout.astro'
 import PropertyDetailPage from '../../../islands/PropertyDetailPage.vue'
-import { readFileSync, readdirSync } from 'node:fs'
-import { resolve } from 'node:path'
 
 export async function getStaticPaths() {
-  const dir = resolve(process.cwd(), 'public', 'unicode', 'indexes', 'bidiclass')
-  let files: string[] = []
-  try { files = readdirSync(dir) } catch { return [] }
-  return files
-    .filter(f => f.endsWith('.json'))
-    .map(f => {
-      const code = f.replace(/\.json$/, '')
-      return { params: { code }, props: { code } }
-    })
+  return []
 }
-
-const { code } = Astro.props
-const property = 'bidiclass'
-const propTitle = 'Bidirectional Class'
 ---
 
-<DefaultLayout title={`Unicode ${propTitle} ${code} — Fontist`}>
-  <PropertyDetailPage property={property} title={propTitle} code={code} client:load />
+<DefaultLayout title="Fontist">
+  <PropertyDetailPage client:only="vue" />
 </DefaultLayout>

--- a/src/pages/unicode/block/[blockSlug].astro
+++ b/src/pages/unicode/block/[blockSlug].astro
@@ -1,29 +1,12 @@
 ---
 import DefaultLayout from '../../../layouts/DefaultLayout.astro'
 import UnicodeBlockPage from '../../../islands/UnicodeBlockPage.vue'
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 
 export async function getStaticPaths() {
-  const blocksPath = resolve(process.cwd(), 'public', 'unicode-blocks.json')
-  let blocksFile: Record<string, { name: string }> = {}
-  try {
-    blocksFile = JSON.parse(readFileSync(blocksPath, 'utf8'))
-  } catch {
-    return []
-  }
-  return Object.values(blocksFile)
-    .map((b) => b.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''))
-    .filter(Boolean)
-    .map((blockSlug) => ({
-      params: { blockSlug },
-      props: { blockSlug },
-    }))
+  return []
 }
-
-const { blockSlug } = Astro.props
 ---
 
-<DefaultLayout title={`Unicode Block ${blockSlug} — Fontist`}>
-  <UnicodeBlockPage blockSlug={blockSlug} client:load />
+<DefaultLayout title="Fontist">
+  <UnicodeBlockPage client:only="vue" />
 </DefaultLayout>

--- a/src/pages/unicode/category/[code].astro
+++ b/src/pages/unicode/category/[code].astro
@@ -1,26 +1,12 @@
 ---
 import DefaultLayout from '../../../layouts/DefaultLayout.astro'
 import PropertyDetailPage from '../../../islands/PropertyDetailPage.vue'
-import { readFileSync, readdirSync } from 'node:fs'
-import { resolve } from 'node:path'
 
 export async function getStaticPaths() {
-  const dir = resolve(process.cwd(), 'public', 'unicode', 'indexes', 'category')
-  let files: string[] = []
-  try { files = readdirSync(dir) } catch { return [] }
-  return files
-    .filter(f => f.endsWith('.json'))
-    .map(f => {
-      const code = f.replace(/\.json$/, '')
-      return { params: { code }, props: { code } }
-    })
+  return []
 }
-
-const { code } = Astro.props
-const property = 'category'
-const propTitle = 'Category'
 ---
 
-<DefaultLayout title={`Unicode ${propTitle} ${code} — Fontist`}>
-  <PropertyDetailPage property={property} title={propTitle} code={code} client:load />
+<DefaultLayout title="Fontist">
+  <PropertyDetailPage client:only="vue" />
 </DefaultLayout>

--- a/src/pages/unicode/char/[hex].astro
+++ b/src/pages/unicode/char/[hex].astro
@@ -1,43 +1,12 @@
 ---
 import DefaultLayout from '../../../layouts/DefaultLayout.astro'
 import UnicodeCharPage from '../../../islands/UnicodeCharPage.vue'
-import { readFileSync, existsSync } from 'node:fs'
-import { resolve } from 'node:path'
 
 export async function getStaticPaths() {
-  // Walk public/codepoints/*.json to enumerate every assigned codepoint
-  // that has at least one font covering it. Each file is a flat list of
-  // hex strings (one codepoint per line, or a JSON array).
-  const cpDir = resolve(process.cwd(), 'public', 'codepoints')
-  if (!existsSync(cpDir)) return []
-  const paths: { params: { hex: string }; props: { hex: string } }[] = []
-  const seen = new Set<string>()
-  function walk(dir: string) {
-    for (const ent of readFileSync ? require('node:fs').readdirSync(dir, { withFileTypes: true }) : []) {
-      const full = resolve(dir, ent.name)
-      if (ent.isDirectory()) {
-        walk(full)
-      } else if (ent.name.endsWith('.json')) {
-        try {
-          const data = JSON.parse(readFileSync(full, 'utf8'))
-          const cps: string[] = Array.isArray(data) ? data : (data.codepoints || [])
-          for (const cp of cps) {
-            const hex = typeof cp === 'number' ? cp.toString(16).toUpperCase().padStart(4, '0') : String(cp)
-            if (seen.has(hex)) continue
-            seen.add(hex)
-            paths.push({ params: { hex }, props: { hex } })
-          }
-        } catch {}
-      }
-    }
-  }
-  try { walk(cpDir) } catch {}
-  return paths
+  return []
 }
-
-const { hex } = Astro.props
 ---
 
-<DefaultLayout title={`Unicode Char U+${hex.toUpperCase()} — Fontist`}>
-  <UnicodeCharPage hex={hex} client:load />
+<DefaultLayout title="Fontist">
+  <UnicodeCharPage client:only="vue" />
 </DefaultLayout>

--- a/src/pages/unicode/combining/[code].astro
+++ b/src/pages/unicode/combining/[code].astro
@@ -1,26 +1,12 @@
 ---
 import DefaultLayout from '../../../layouts/DefaultLayout.astro'
 import PropertyDetailPage from '../../../islands/PropertyDetailPage.vue'
-import { readFileSync, readdirSync } from 'node:fs'
-import { resolve } from 'node:path'
 
 export async function getStaticPaths() {
-  const dir = resolve(process.cwd(), 'public', 'unicode', 'indexes', 'combining')
-  let files: string[] = []
-  try { files = readdirSync(dir) } catch { return [] }
-  return files
-    .filter(f => f.endsWith('.json'))
-    .map(f => {
-      const code = f.replace(/\.json$/, '')
-      return { params: { code }, props: { code } }
-    })
+  return []
 }
-
-const { code } = Astro.props
-const property = 'combining'
-const propTitle = 'Combining Class'
 ---
 
-<DefaultLayout title={`Unicode ${propTitle} ${code} — Fontist`}>
-  <PropertyDetailPage property={property} title={propTitle} code={code} client:load />
+<DefaultLayout title="Fontist">
+  <PropertyDetailPage client:only="vue" />
 </DefaultLayout>

--- a/src/pages/unicode/scripts/[code].astro
+++ b/src/pages/unicode/scripts/[code].astro
@@ -1,26 +1,12 @@
 ---
 import DefaultLayout from '../../../layouts/DefaultLayout.astro'
 import PropertyDetailPage from '../../../islands/PropertyDetailPage.vue'
-import { readFileSync, readdirSync } from 'node:fs'
-import { resolve } from 'node:path'
 
 export async function getStaticPaths() {
-  const dir = resolve(process.cwd(), 'public', 'unicode', 'indexes', 'scripts')
-  let files: string[] = []
-  try { files = readdirSync(dir) } catch { return [] }
-  return files
-    .filter(f => f.endsWith('.json'))
-    .map(f => {
-      const code = f.replace(/\.json$/, '')
-      return { params: { code }, props: { code } }
-    })
+  return []
 }
-
-const { code } = Astro.props
-const property = 'scripts'
-const propTitle = 'Script'
 ---
 
-<DefaultLayout title={`Unicode ${propTitle} ${code} — Fontist`}>
-  <PropertyDetailPage property={property} title={propTitle} code={code} client:load />
+<DefaultLayout title="Fontist">
+  <PropertyDetailPage client:only="vue" />
 </DefaultLayout>


### PR DESCRIPTION
## Summary

Site was 3.0 GB (3x GitHub Pages' 1 GB limit). Fixed by using a SPA fallback for high-cardinality dynamic routes.

- **Before:** 37,428 pre-rendered HTML pages, 3.0 GB
- **After:** 63 pre-rendered pages + SPA fallback, 593 MB

Dynamic routes (formulas, fonts, families, unicode) served by 404.html SPA that detects URL and imports the right Vue island.

## Test plan

- [x] Astro build: 63 pages, 5.6s
- [x] Vitest: 150 tests pass
- [x] Node tests: 253 pass
- [x] Static pages (blog, guide, licenses, about) render with real content
- [x] dist/ size: 593 MB (under 1 GB limit)
