### PR TITLE
fix: reorder nav — News first, Docs last with separator

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -37,12 +37,12 @@ function onKey(e: KeyboardEvent) {
 }
 
 const navLinks = [
+  { href: '/blog', label: 'News' },
   { href: '/formulas', label: 'Formulas' },
   { href: '/families', label: 'Families' },
   { href: '/licenses', label: 'Licenses' },
   { href: '/guide', label: 'Guide' },
   { href: '/unicode', label: 'Unicode' },
-  { href: '/blog', label: 'Blog' },
   { href: '/about', label: 'About' },
 ]
 
@@ -75,8 +75,6 @@ onBeforeUnmount(() => {
         role="navigation"
         aria-label="Main"
       >
-        <DocsDropdown />
-
         <a
           v-for="link in navLinks"
           :key="link.href"
@@ -87,6 +85,9 @@ onBeforeUnmount(() => {
         >
           {{ link.label }}
         </a>
+
+        <span class="mx-1 h-4 w-px bg-rule" aria-hidden="true"></span>
+        <DocsDropdown />
       </div>
 
       <div class="flex flex-shrink-0 items-center gap-1">


### PR DESCRIPTION
## Summary

Nav priority reordered to reflect actual usage:

**Before:** Docs, Formulas, Families, Licenses, Guide, Unicode, Blog, About
**After:** News, Formulas, Families, Licenses, Guide, Unicode, About | Docs

- **News** (renamed from Blog) moved to first position — most frequently updated content
- **Docs** moved to last position after a visual rule separator — links to external subsites (fontist.org/fontist, fontist.org/fontisan), not part of the main site navigation

## Test plan

- [x] Build succeeds (63 pages)
- [x] Nav order verified in built HTML: News, Formulas, Families, Licenses, Guide, Unicode, About, [separator], Docs
- [ ] CI passes