### PR TITLE
fix: remove fake masthead, colophon, and Astro+Vue footer credit

### DIFF
--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -91,7 +91,5 @@ const COLUMNS: { title: string; links: { label: string; to: string; external?: b
     <span class="sf-base-copy">© {year} Fontist · Ribose Ltd.</span>
     <span class="sf-base-sep" aria-hidden="true">·</span>
     <a href="https://github.com/fontist/fontist.org" class="sf-base-link">Source on GitHub</a>
-    <span class="sf-base-sep" aria-hidden="true">·</span>
-    <span class="sf-base-meta">Built with Astro + Vue islands</span>
   </div>
 </footer>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -56,12 +56,6 @@ const instruments = [
   canonical="https://www.fontist.org/"
 >
   <div class="specimen">
-    <!-- Masthead -->
-    <div class="masthead">
-      <span class="c">A Specimen for Cross-Platform Font Management</span>
-      <span class="r">Vol. 01 / MMXXVI</span>
-    </div>
-
     <!-- Hero -->
     <section class="hero">
       <div class="ghost-numeral" aria-hidden="true">01</div>
@@ -282,11 +276,5 @@ const instruments = [
         </div>
       </div>
     </section>
-
-    <!-- Footer colophon -->
-    <footer class="foot">
-      <span>Set in <em>Spectral</em>, <em>IBM&nbsp;Plex</em>, &amp; <em>JetBrains&nbsp;Mono</em>.</span>
-      <span class="r">Fontist · a Ribose project · © MMXXVI</span>
-    </footer>
   </div>
 </DefaultLayout>


### PR DESCRIPTION
## Summary

Deleted three pieces of text that don't belong on the site:

1. **Homepage masthead** — 'A Specimen for Cross-Platform Font Management / Vol. 01 / MMXXVI' — fake editorial chrome
2. **Homepage footer colophon** — 'Set in Spectral, IBM Plex, & JetBrains Mono / Fontist · a Ribose project · © MMXXVI' — implementation detail, not content
3. **Site footer meta** — 'Built with Astro + Vue islands' — implementation detail that doesn't belong in the footer

## Test plan

- [x] Build succeeds (63 pages)
- [x] Verified all text removed from built HTML output