### PR TITLE
fix: restore complete favicon setup lost during Astro migration

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "MyWebSite",
-  "short_name": "MySite",
+  "name": "Fontist",
+  "short_name": "Fontist",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",
@@ -15,7 +15,7 @@
       "purpose": "maskable"
     }
   ],
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff",
+  "theme_color": "#f1ece1",
+  "background_color": "#f1ece1",
   "display": "standalone"
 }

--- a/src/layouts/DefaultLayout.astro
+++ b/src/layouts/DefaultLayout.astro
@@ -17,6 +17,11 @@ const currentPath = Astro.url.pathname
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#f1ece1" />
     <title>{title}</title>
     {description && <meta name="description" content={description} />}
     {canonical && <link rel="canonical" href={canonical} />}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -9,6 +9,11 @@ import SiteFooter from '../components/SiteFooter.astro'
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#f1ece1" />
     <title>Fontist</title>
     <script is:inline>
       (function(){try{var k='fontist-theme';var s=localStorage.getItem(k);var t=s==='light'||s==='dark'?s:(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');if(t==='dark')document.documentElement.classList.add('dark')}catch(e){}})();


### PR DESCRIPTION
## Summary

The original vite-ssg setup had four favicon link tags. The Astro migration only kept , losing cross-browser/device support.

Restored in both DefaultLayout.astro and 404.astro:
-  (modern browsers)
-  (legacy browsers, tab fallback)
-  180x180 (iOS home screen)
-  (Android Chrome)
-  (PWA metadata)
-  meta ( paper tone)

Also fixed :
-  → Commands:
  Fontist cache SUBCOMMAND ...ARGS         # Manage fontist cache
  Fontist config SUBCOMMAND ...ARGS        # Manage fontist config
  Fontist create-formula URL               # Create a new formula with fonts ...
  Fontist find                             # Find fonts by capabilities
  Fontist fontconfig SUBCOMMAND ...ARGS    # Manage fontconfig
  Fontist help [COMMAND]                   # Describe available commands or o...
  Fontist import SUBCOMMAND ...ARGS        # Manage imports
  Fontist index SUBCOMMAND ...ARGS         # Manage system font index
  Fontist install FONT...                  # Install one or more fonts
  Fontist list [FONT]                      # List installation status of FONT...
  Fontist macos-catalogs                   # List available macOS font catalogs
  Fontist manifest SUBCOMMAND ...ARGS      # Manage font manifests
  Fontist migrate-formulas INPUT [OUTPUT]  # Migrate v4 formulas to v5 schema
  Fontist rebuild-index                    # Rebuild formula index (used by f...
  Fontist repo SUBCOMMAND ...ARGS          # Manage custom repositories
  Fontist status [FONT]                    # Show paths of FONT or all fonts
  Fontist tree                             # Print a tree of all available co...
  Fontist uninstall/remove FONT            # Uninstall font by font or formula
  Fontist update                           # Update formulas
  Fontist version                          # Show fontist version

Options:
      [--preferred-family], [--no-preferred-family], [--skip-preferred-family]  # Use Preferred Family when available
  -q, [--quiet], [--no-quiet], [--skip-quiet]                                   # Hide all messages
  -v, [--verbose], [--no-verbose], [--skip-verbose]                             # Print debug messages
  -c, [--no-cache]                                                              # Avoid using cache during download
  -i, [--interactive], [--no-interactive], [--skip-interactive]                 # Interactive mode
                                                                                # Default: true
      [--formulas-path=FORMULAS_PATH]                                           # Path to formulas
-  → Commands:
  Fontist cache SUBCOMMAND ...ARGS         # Manage fontist cache
  Fontist config SUBCOMMAND ...ARGS        # Manage fontist config
  Fontist create-formula URL               # Create a new formula with fonts ...
  Fontist find                             # Find fonts by capabilities
  Fontist fontconfig SUBCOMMAND ...ARGS    # Manage fontconfig
  Fontist help [COMMAND]                   # Describe available commands or o...
  Fontist import SUBCOMMAND ...ARGS        # Manage imports
  Fontist index SUBCOMMAND ...ARGS         # Manage system font index
  Fontist install FONT...                  # Install one or more fonts
  Fontist list [FONT]                      # List installation status of FONT...
  Fontist macos-catalogs                   # List available macOS font catalogs
  Fontist manifest SUBCOMMAND ...ARGS      # Manage font manifests
  Fontist migrate-formulas INPUT [OUTPUT]  # Migrate v4 formulas to v5 schema
  Fontist rebuild-index                    # Rebuild formula index (used by f...
  Fontist repo SUBCOMMAND ...ARGS          # Manage custom repositories
  Fontist status [FONT]                    # Show paths of FONT or all fonts
  Fontist tree                             # Print a tree of all available co...
  Fontist uninstall/remove FONT            # Uninstall font by font or formula
  Fontist update                           # Update formulas
  Fontist version                          # Show fontist version

Options:
      [--preferred-family], [--no-preferred-family], [--skip-preferred-family]  # Use Preferred Family when available
  -q, [--quiet], [--no-quiet], [--skip-quiet]                                   # Hide all messages
  -v, [--verbose], [--no-verbose], [--skip-verbose]                             # Print debug messages
  -c, [--no-cache]                                                              # Avoid using cache during download
  -i, [--interactive], [--no-interactive], [--skip-interactive]                 # Interactive mode
                                                                                # Default: true
      [--formulas-path=FORMULAS_PATH]                                           # Path to formulas
- / → 

## Test plan

- [x] Build succeeds (63 pages)
- [x] All 6 favicon/meta tags verified in built HTML