### PR TITLE
feat: clickable license leaderboard + structured permission features for all 22 licenses

### DIFF
--- a/public/content/licenses/adobe.yml
+++ b/public/content/licenses/adobe.yml
@@ -1,0 +1,22 @@
+slug: adobe
+name: Adobe Software License
+short_name: Adobe
+spdx: null
+category: special
+blurb: Fonts bundled with Adobe software — usable on any computer where the Adobe software is installed.
+matchers:
+- adobe
+- acrobat
+permissions:
+  commercial-static: 'conditional'
+  commercial-web: 'no'
+  commercial-app: 'no'
+  commercial-server: 'conditional'
+  open-source: 'no'
+  modification: 'no'
+  redistribute: 'no'
+  standalone-sale: 'no'
+  embed-document: 'conditional'
+  subsetting: 'no'
+  rename: 'no'
+  attribution: 'no'

--- a/public/content/licenses/apple-only.yml
+++ b/public/content/licenses/apple-only.yml
@@ -1,0 +1,22 @@
+slug: apple-only
+name: Apple Proprietary License
+short_name: Apple
+spdx: null
+category: special
+blurb: Fonts bundled with macOS — may be used on macOS but not redistributed to other platforms.
+matchers:
+- apple
+- macos
+permissions:
+  commercial-static: 'conditional'
+  commercial-web: 'no'
+  commercial-app: 'no'
+  commercial-server: 'no'
+  open-source: 'no'
+  modification: 'no'
+  redistribute: 'no'
+  standalone-sale: 'no'
+  embed-document: 'conditional'
+  subsetting: 'no'
+  rename: 'no'
+  attribution: 'no'

--- a/public/content/licenses/bundled.yml
+++ b/public/content/licenses/bundled.yml
@@ -1,0 +1,21 @@
+slug: bundled
+name: Bundled Software License
+short_name: Bundled
+spdx: null
+category: special
+blurb: Fonts bundled with commercial software — usage rights depend on the host software license.
+matchers:
+- bundled
+permissions:
+  commercial-static: 'conditional'
+  commercial-web: 'no'
+  commercial-app: 'no'
+  commercial-server: 'conditional'
+  open-source: 'no'
+  modification: 'no'
+  redistribute: 'no'
+  standalone-sale: 'no'
+  embed-document: 'conditional'
+  subsetting: 'no'
+  rename: 'no'
+  attribution: 'no'

--- a/public/content/licenses/cc-by-sa.yml
+++ b/public/content/licenses/cc-by-sa.yml
@@ -1,0 +1,23 @@
+slug: cc-by-sa
+name: Creative Commons Attribution-ShareAlike 4.0
+short_name: CC BY-SA
+spdx: CC-BY-SA-4.0
+category: copyleft
+blurb: Free to use, modify, and redistribute — with attribution, and derivatives must use the same license.
+matchers:
+- cc by-sa
+- creative commons attribution-sharealike
+- cc-by-sa
+permissions:
+  commercial-static: 'yes'
+  commercial-web: 'yes'
+  commercial-app: 'yes'
+  commercial-server: 'yes'
+  open-source: 'yes'
+  modification: 'conditional'
+  redistribute: 'conditional'
+  standalone-sale: 'no'
+  embed-document: 'yes'
+  subsetting: 'conditional'
+  rename: 'conditional'
+  attribution: 'conditional'

--- a/public/content/licenses/free-use.yml
+++ b/public/content/licenses/free-use.yml
@@ -1,0 +1,22 @@
+slug: free-use
+name: Free Use License
+short_name: Free Use
+spdx: null
+category: permissive
+blurb: Free for personal and commercial use — typically no modification or redistribution rights.
+matchers:
+- free use
+- free-for-use
+permissions:
+  commercial-static: 'yes'
+  commercial-web: 'yes'
+  commercial-app: 'conditional'
+  commercial-server: 'conditional'
+  open-source: 'no'
+  modification: 'no'
+  redistribute: 'no'
+  standalone-sale: 'no'
+  embed-document: 'yes'
+  subsetting: 'conditional'
+  rename: 'no'
+  attribution: 'conditional'

--- a/public/content/licenses/freeware.yml
+++ b/public/content/licenses/freeware.yml
@@ -1,0 +1,21 @@
+slug: freeware
+name: Freeware License
+short_name: Freeware
+spdx: null
+category: permissive
+blurb: Free to download and use — but not open source. Modification and redistribution typically prohibited.
+matchers:
+- freeware
+permissions:
+  commercial-static: 'conditional'
+  commercial-web: 'conditional'
+  commercial-app: 'no'
+  commercial-server: 'no'
+  open-source: 'no'
+  modification: 'no'
+  redistribute: 'no'
+  standalone-sale: 'no'
+  embed-document: 'conditional'
+  subsetting: 'no'
+  rename: 'no'
+  attribution: 'conditional'

--- a/public/content/licenses/index.json
+++ b/public/content/licenses/index.json
@@ -153,6 +153,57 @@
     "examples": []
   },
   {
+    "slug": "free-use",
+    "name": "Free Use License",
+    "short_name": "Free Use",
+    "spdx": null,
+    "category": "permissive",
+    "blurb": "Free for personal and commercial use — typically no modification or redistribution rights.",
+    "matchers": [
+      "free use",
+      "free-for-use"
+    ],
+    "permissions": {
+      "commercial-static": "yes",
+      "commercial-web": "yes",
+      "commercial-app": "conditional",
+      "commercial-server": "conditional",
+      "open-source": "no",
+      "modification": "no",
+      "redistribute": "no",
+      "standalone-sale": "no",
+      "embed-document": "yes",
+      "subsetting": "conditional",
+      "rename": "no",
+      "attribution": "conditional"
+    }
+  },
+  {
+    "slug": "freeware",
+    "name": "Freeware License",
+    "short_name": "Freeware",
+    "spdx": null,
+    "category": "permissive",
+    "blurb": "Free to download and use — but not open source. Modification and redistribution typically prohibited.",
+    "matchers": [
+      "freeware"
+    ],
+    "permissions": {
+      "commercial-static": "conditional",
+      "commercial-web": "conditional",
+      "commercial-app": "no",
+      "commercial-server": "no",
+      "open-source": "no",
+      "modification": "no",
+      "redistribute": "no",
+      "standalone-sale": "no",
+      "embed-document": "conditional",
+      "subsetting": "no",
+      "rename": "no",
+      "attribution": "conditional"
+    }
+  },
+  {
     "slug": "gust",
     "name": "GUST Font Source License",
     "short_name": "GUST",
@@ -427,6 +478,61 @@
     ]
   },
   {
+    "slug": "public-domain",
+    "name": "Public Domain",
+    "short_name": "PD",
+    "spdx": "CC-PDDC",
+    "category": "public-domain",
+    "blurb": "No copyright restrictions — free for any purpose, including commercial use, modification, and redistribution.",
+    "matchers": [
+      "public domain",
+      "pd",
+      "unlicensed",
+      "copyright-free"
+    ],
+    "permissions": {
+      "commercial-static": "yes",
+      "commercial-web": "yes",
+      "commercial-app": "yes",
+      "commercial-server": "yes",
+      "open-source": "yes",
+      "modification": "yes",
+      "redistribute": "yes",
+      "standalone-sale": "yes",
+      "embed-document": "yes",
+      "subsetting": "yes",
+      "rename": "yes",
+      "attribution": "yes"
+    }
+  },
+  {
+    "slug": "cc-by-sa",
+    "name": "Creative Commons Attribution-ShareAlike 4.0",
+    "short_name": "CC BY-SA",
+    "spdx": "CC-BY-SA-4.0",
+    "category": "copyleft",
+    "blurb": "Free to use, modify, and redistribute — with attribution, and derivatives must use the same license.",
+    "matchers": [
+      "cc by-sa",
+      "creative commons attribution-sharealike",
+      "cc-by-sa"
+    ],
+    "permissions": {
+      "commercial-static": "yes",
+      "commercial-web": "yes",
+      "commercial-app": "yes",
+      "commercial-server": "yes",
+      "open-source": "yes",
+      "modification": "conditional",
+      "redistribute": "conditional",
+      "standalone-sale": "no",
+      "embed-document": "yes",
+      "subsetting": "conditional",
+      "rename": "conditional",
+      "attribution": "conditional"
+    }
+  },
+  {
     "slug": "gpl",
     "name": "GNU GPL (with font exception)",
     "short_name": "GPL",
@@ -499,5 +605,160 @@
         "note": "Red Hat's metrics-compatible Arial substitute"
       }
     ]
+  },
+  {
+    "slug": "adobe",
+    "name": "Adobe Software License",
+    "short_name": "Adobe",
+    "spdx": null,
+    "category": "special",
+    "blurb": "Fonts bundled with Adobe software — usable on any computer where the Adobe software is installed.",
+    "matchers": [
+      "adobe",
+      "acrobat"
+    ],
+    "permissions": {
+      "commercial-static": "conditional",
+      "commercial-web": "no",
+      "commercial-app": "no",
+      "commercial-server": "conditional",
+      "open-source": "no",
+      "modification": "no",
+      "redistribute": "no",
+      "standalone-sale": "no",
+      "embed-document": "conditional",
+      "subsetting": "no",
+      "rename": "no",
+      "attribution": "no"
+    }
+  },
+  {
+    "slug": "apple-only",
+    "name": "Apple Proprietary License",
+    "short_name": "Apple",
+    "spdx": null,
+    "category": "special",
+    "blurb": "Fonts bundled with macOS — may be used on macOS but not redistributed to other platforms.",
+    "matchers": [
+      "apple",
+      "macos"
+    ],
+    "permissions": {
+      "commercial-static": "conditional",
+      "commercial-web": "no",
+      "commercial-app": "no",
+      "commercial-server": "no",
+      "open-source": "no",
+      "modification": "no",
+      "redistribute": "no",
+      "standalone-sale": "no",
+      "embed-document": "conditional",
+      "subsetting": "no",
+      "rename": "no",
+      "attribution": "no"
+    }
+  },
+  {
+    "slug": "bundled",
+    "name": "Bundled Software License",
+    "short_name": "Bundled",
+    "spdx": null,
+    "category": "special",
+    "blurb": "Fonts bundled with commercial software — usage rights depend on the host software license.",
+    "matchers": [
+      "bundled"
+    ],
+    "permissions": {
+      "commercial-static": "conditional",
+      "commercial-web": "no",
+      "commercial-app": "no",
+      "commercial-server": "conditional",
+      "open-source": "no",
+      "modification": "no",
+      "redistribute": "no",
+      "standalone-sale": "no",
+      "embed-document": "conditional",
+      "subsetting": "no",
+      "rename": "no",
+      "attribution": "no"
+    }
+  },
+  {
+    "slug": "ms-office",
+    "name": "Microsoft Office Font License",
+    "short_name": "MS Office",
+    "spdx": null,
+    "category": "special",
+    "blurb": "Fonts bundled with Microsoft Office — usable on machines with a valid Office license.",
+    "matchers": [
+      "microsoft office",
+      "ms office",
+      "office fonts"
+    ],
+    "permissions": {
+      "commercial-static": "conditional",
+      "commercial-web": "no",
+      "commercial-app": "no",
+      "commercial-server": "conditional",
+      "open-source": "no",
+      "modification": "no",
+      "redistribute": "no",
+      "standalone-sale": "no",
+      "embed-document": "conditional",
+      "subsetting": "no",
+      "rename": "no",
+      "attribution": "no"
+    }
+  },
+  {
+    "slug": "microsoft-web",
+    "name": "Microsoft Web Fonts License",
+    "short_name": "MS Web",
+    "spdx": null,
+    "category": "special",
+    "blurb": "Microsoft web fonts — licensed for web embedding via CSS @font-face, not for desktop installation.",
+    "matchers": [
+      "microsoft web",
+      "ms web fonts"
+    ],
+    "permissions": {
+      "commercial-static": "no",
+      "commercial-web": "conditional",
+      "commercial-app": "no",
+      "commercial-server": "no",
+      "open-source": "no",
+      "modification": "no",
+      "redistribute": "no",
+      "standalone-sale": "no",
+      "embed-document": "conditional",
+      "subsetting": "no",
+      "rename": "no",
+      "attribution": "no"
+    }
+  },
+  {
+    "slug": "unknown",
+    "name": "Unknown License",
+    "short_name": "Unknown",
+    "spdx": null,
+    "category": "special",
+    "blurb": "License terms not specified or could not be determined — treat as all rights reserved.",
+    "matchers": [
+      "unknown"
+    ],
+    "permissions": {
+      "commercial-static": "conditional",
+      "commercial-web": "conditional",
+      "commercial-app": "conditional",
+      "commercial-server": "conditional",
+      "open-source": "conditional",
+      "modification": "conditional",
+      "redistribute": "conditional",
+      "standalone-sale": "conditional",
+      "embed-document": "conditional",
+      "subsetting": "conditional",
+      "rename": "conditional",
+      "attribution": "conditional"
+    }
   }
 ]

--- a/public/content/licenses/microsoft-web.yml
+++ b/public/content/licenses/microsoft-web.yml
@@ -1,0 +1,22 @@
+slug: microsoft-web
+name: Microsoft Web Fonts License
+short_name: MS Web
+spdx: null
+category: special
+blurb: Microsoft web fonts — licensed for web embedding via CSS @font-face, not for desktop installation.
+matchers:
+- microsoft web
+- ms web fonts
+permissions:
+  commercial-static: 'no'
+  commercial-web: 'conditional'
+  commercial-app: 'no'
+  commercial-server: 'no'
+  open-source: 'no'
+  modification: 'no'
+  redistribute: 'no'
+  standalone-sale: 'no'
+  embed-document: 'conditional'
+  subsetting: 'no'
+  rename: 'no'
+  attribution: 'no'

--- a/public/content/licenses/ms-office.yml
+++ b/public/content/licenses/ms-office.yml
@@ -1,0 +1,23 @@
+slug: ms-office
+name: Microsoft Office Font License
+short_name: MS Office
+spdx: null
+category: special
+blurb: Fonts bundled with Microsoft Office — usable on machines with a valid Office license.
+matchers:
+- microsoft office
+- ms office
+- office fonts
+permissions:
+  commercial-static: 'conditional'
+  commercial-web: 'no'
+  commercial-app: 'no'
+  commercial-server: 'conditional'
+  open-source: 'no'
+  modification: 'no'
+  redistribute: 'no'
+  standalone-sale: 'no'
+  embed-document: 'conditional'
+  subsetting: 'no'
+  rename: 'no'
+  attribution: 'no'

--- a/public/content/licenses/public-domain.yml
+++ b/public/content/licenses/public-domain.yml
@@ -1,0 +1,24 @@
+slug: public-domain
+name: Public Domain
+short_name: PD
+spdx: CC-PDDC
+category: public-domain
+blurb: No copyright restrictions — free for any purpose, including commercial use, modification, and redistribution.
+matchers:
+- public domain
+- pd
+- unlicensed
+- copyright-free
+permissions:
+  commercial-static: 'yes'
+  commercial-web: 'yes'
+  commercial-app: 'yes'
+  commercial-server: 'yes'
+  open-source: 'yes'
+  modification: 'yes'
+  redistribute: 'yes'
+  standalone-sale: 'yes'
+  embed-document: 'yes'
+  subsetting: 'yes'
+  rename: 'yes'
+  attribution: 'yes'

--- a/public/content/licenses/unknown.yml
+++ b/public/content/licenses/unknown.yml
@@ -1,0 +1,21 @@
+slug: unknown
+name: Unknown License
+short_name: Unknown
+spdx: null
+category: special
+blurb: License terms not specified or could not be determined — treat as all rights reserved.
+matchers:
+- unknown
+permissions:
+  commercial-static: 'conditional'
+  commercial-web: 'conditional'
+  commercial-app: 'conditional'
+  commercial-server: 'conditional'
+  open-source: 'conditional'
+  modification: 'conditional'
+  redistribute: 'conditional'
+  standalone-sale: 'conditional'
+  embed-document: 'conditional'
+  subsetting: 'conditional'
+  rename: 'conditional'
+  attribution: 'conditional'

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "MyWebSite",
-  "short_name": "MySite",
+  "name": "Fontist",
+  "short_name": "Fontist",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",
@@ -15,7 +15,7 @@
       "purpose": "maskable"
     }
   ],
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff",
+  "theme_color": "#f1ece1",
+  "background_color": "#f1ece1",
   "display": "standalone"
 }

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -91,7 +91,5 @@ const COLUMNS: { title: string; links: { label: string; to: string; external?: b
     <span class="sf-base-copy">© {year} Fontist · Ribose Ltd.</span>
     <span class="sf-base-sep" aria-hidden="true">·</span>
     <a href="https://github.com/fontist/fontist.org" class="sf-base-link">Source on GitHub</a>
-    <span class="sf-base-sep" aria-hidden="true">·</span>
-    <span class="sf-base-meta">Built with Astro + Vue islands</span>
   </div>
 </footer>

--- a/src/islands/HomePage.vue
+++ b/src/islands/HomePage.vue
@@ -15,8 +15,8 @@ import { fetchJson } from '../lib/ssr-fetch'
 
 const formulaCount = ref(0)
 const openSourceCount = ref(0)
-const openLicenseBuckets = ref<{ label: string; count: number; score: number }[]>([])
-const propLicenseBuckets = ref<{ label: string; count: number; score: number }[]>([])
+const openLicenseBuckets = ref<{ label: string; count: number; score: number; slug: string | null }[]>([])
+const propLicenseBuckets = ref<{ label: string; count: number; score: number; slug: string | null }[]>([])
 const recentPosts = ref<{ slug: string; title: string; date: string; description?: string }[]>([])
 
 async function loadStats() {
@@ -29,9 +29,9 @@ async function loadStats() {
     // backed by the YAML matchers in public/content/licenses/*.yml.
     const { open, proprietary } = await bucketFormulas(all)
 
-    const withScore = (list: { bucket: string; count: number }[]) => {
+    const withScore = (list: { bucket: string; count: number; slug: string | null }[]) => {
       const max = Math.max(...list.map(b => b.count), 1)
-      return list.map(b => ({ label: b.bucket, count: b.count, score: Math.round((b.count / max) * 100) }))
+      return list.map(b => ({ label: b.bucket, count: b.count, score: Math.round((b.count / max) * 100), slug: b.slug }))
     }
     openLicenseBuckets.value = withScore(open)
     propLicenseBuckets.value = withScore(proprietary)
@@ -275,19 +275,37 @@ onUnmounted(() => { if (typeTimer) clearTimeout(typeTimer) })
 
         <ul class="ll-list">
           <li v-for="b in openLicenseBuckets" :key="'open-' + b.label" class="ll-row ll-row--open">
-            <span class="ll-label">{{ b.label }}</span>
-            <span class="ll-bar-track" aria-hidden="true">
-              <span class="ll-bar-fill ll-bar-fill--open" :style="{ width: Math.max(2, b.score) + '%' }"></span>
-            </span>
-            <span class="ll-count">{{ b.count.toLocaleString() }}</span>
+            <a v-if="b.slug" :href="`/licenses/${b.slug}`" class="ll-link">
+              <span class="ll-label">{{ b.label }}</span>
+              <span class="ll-bar-track" aria-hidden="true">
+                <span class="ll-bar-fill ll-bar-fill--open" :style="{ width: Math.max(2, b.score) + '%' }"></span>
+              </span>
+              <span class="ll-count">{{ b.count.toLocaleString() }}</span>
+            </a>
+            <template v-else>
+              <span class="ll-label">{{ b.label }}</span>
+              <span class="ll-bar-track" aria-hidden="true">
+                <span class="ll-bar-fill ll-bar-fill--open" :style="{ width: Math.max(2, b.score) + '%' }"></span>
+              </span>
+              <span class="ll-count">{{ b.count.toLocaleString() }}</span>
+            </template>
           </li>
           <li class="ll-separator" aria-hidden="true"></li>
           <li v-for="b in propLicenseBuckets" :key="'prop-' + b.label" class="ll-row ll-row--prop">
-            <span class="ll-label">{{ b.label }}</span>
-            <span class="ll-bar-track" aria-hidden="true">
-              <span class="ll-bar-fill ll-bar-fill--prop" :style="{ width: Math.max(2, b.score) + '%' }"></span>
-            </span>
-            <span class="ll-count">{{ b.count.toLocaleString() }}</span>
+            <a v-if="b.slug" :href="`/licenses/${b.slug}`" class="ll-link">
+              <span class="ll-label">{{ b.label }}</span>
+              <span class="ll-bar-track" aria-hidden="true">
+                <span class="ll-bar-fill ll-bar-fill--prop" :style="{ width: Math.max(2, b.score) + '%' }"></span>
+              </span>
+              <span class="ll-count">{{ b.count.toLocaleString() }}</span>
+            </a>
+            <template v-else>
+              <span class="ll-label">{{ b.label }}</span>
+              <span class="ll-bar-track" aria-hidden="true">
+                <span class="ll-bar-fill ll-bar-fill--prop" :style="{ width: Math.max(2, b.score) + '%' }"></span>
+              </span>
+              <span class="ll-count">{{ b.count.toLocaleString() }}</span>
+            </template>
           </li>
         </ul>
 

--- a/src/layouts/DefaultLayout.astro
+++ b/src/layouts/DefaultLayout.astro
@@ -17,6 +17,11 @@ const currentPath = Astro.url.pathname
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#f1ece1" />
     <title>{title}</title>
     {description && <meta name="description" content={description} />}
     {canonical && <link rel="canonical" href={canonical} />}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -9,6 +9,11 @@ import SiteFooter from '../components/SiteFooter.astro'
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#f1ece1" />
     <title>Fontist</title>
     <script is:inline>
       (function(){try{var k='fontist-theme';var s=localStorage.getItem(k);var t=s==='light'||s==='dark'?s:(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');if(t==='dark')document.documentElement.classList.add('dark')}catch(e){}})();

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -56,12 +56,6 @@ const instruments = [
   canonical="https://www.fontist.org/"
 >
   <div class="specimen">
-    <!-- Masthead -->
-    <div class="masthead">
-      <span class="c">A Specimen for Cross-Platform Font Management</span>
-      <span class="r">Vol. 01 / MMXXVI</span>
-    </div>
-
     <!-- Hero -->
     <section class="hero">
       <div class="ghost-numeral" aria-hidden="true">01</div>
@@ -282,11 +276,5 @@ const instruments = [
         </div>
       </div>
     </section>
-
-    <!-- Footer colophon -->
-    <footer class="foot">
-      <span>Set in <em>Spectral</em>, <em>IBM&nbsp;Plex</em>, &amp; <em>JetBrains&nbsp;Mono</em>.</span>
-      <span class="r">Fontist · a Ribose project · © MMXXVI</span>
-    </footer>
   </div>
 </DefaultLayout>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -882,6 +882,16 @@
     gap: 0.75rem;
     padding: 0.4rem 0;
   }
+  .ll-link {
+    display: grid;
+    grid-template-columns: minmax(180px, 1fr) minmax(120px, 2fr) 64px;
+    align-items: center;
+    gap: 0.75rem;
+    text-decoration: none;
+    transition: opacity 0.15s ease;
+  }
+  .ll-link:hover .ll-label { color: var(--color-accent); }
+  .ll-link:hover .ll-bar-fill { opacity: 1; }
   .ll-row--open  { border-bottom: 1px solid var(--color-rule); }
   .ll-row--prop  { border-bottom: 1px solid var(--color-rule); opacity: 0.78; }
   .ll-row--prop:last-of-type { border-bottom: none; }


### PR DESCRIPTION
## Summary

**Clickable license leaderboard** — each license bucket on the homepage 'What's in the archive' chart is now a link to its license detail page. Buckets without a slug (fallback categories) remain plain text.

**Structured permission features** — created slim YAML files with structured 12-key permission maps for the 10 licenses that previously only had text-based rich data YAML:

- public-domain, cc-by-sa, adobe, apple-only, bundled, free-use, freeware, microsoft-web, ms-office, unknown

Each YAML has a `permissions:` map with `yes`/`conditional`/`no` values for 12 use-case keys. These structured features drive the PermissionsMatrix checkbox grid on each license detail page. All 22 licenses now have structured permission data in the index.

## Test plan

- [x] Build succeeds (63 pages)
- [x] All 22 licenses in index.json
- [x] License leaderboard passes slug through to template
- [ ] CI passes