### PR TITLE
feat: editorial restyle + pagination for families and formulas pages

### DIFF
--- a/public/content/licenses/adobe.yml
+++ b/public/content/licenses/adobe.yml
@@ -1,0 +1,22 @@
+slug: adobe
+name: Adobe Software License
+short_name: Adobe
+spdx: null
+category: special
+blurb: Fonts bundled with Adobe software — usable on any computer where the Adobe software is installed.
+matchers:
+- adobe
+- acrobat
+permissions:
+  commercial-static: 'conditional'
+  commercial-web: 'no'
+  commercial-app: 'no'
+  commercial-server: 'conditional'
+  open-source: 'no'
+  modification: 'no'
+  redistribute: 'no'
+  standalone-sale: 'no'
+  embed-document: 'conditional'
+  subsetting: 'no'
+  rename: 'no'
+  attribution: 'no'

--- a/public/content/licenses/apple-only.yml
+++ b/public/content/licenses/apple-only.yml
@@ -1,0 +1,22 @@
+slug: apple-only
+name: Apple Proprietary License
+short_name: Apple
+spdx: null
+category: special
+blurb: Fonts bundled with macOS — may be used on macOS but not redistributed to other platforms.
+matchers:
+- apple
+- macos
+permissions:
+  commercial-static: 'conditional'
+  commercial-web: 'no'
+  commercial-app: 'no'
+  commercial-server: 'no'
+  open-source: 'no'
+  modification: 'no'
+  redistribute: 'no'
+  standalone-sale: 'no'
+  embed-document: 'conditional'
+  subsetting: 'no'
+  rename: 'no'
+  attribution: 'no'

--- a/public/content/licenses/bundled.yml
+++ b/public/content/licenses/bundled.yml
@@ -1,0 +1,21 @@
+slug: bundled
+name: Bundled Software License
+short_name: Bundled
+spdx: null
+category: special
+blurb: Fonts bundled with commercial software — usage rights depend on the host software license.
+matchers:
+- bundled
+permissions:
+  commercial-static: 'conditional'
+  commercial-web: 'no'
+  commercial-app: 'no'
+  commercial-server: 'conditional'
+  open-source: 'no'
+  modification: 'no'
+  redistribute: 'no'
+  standalone-sale: 'no'
+  embed-document: 'conditional'
+  subsetting: 'no'
+  rename: 'no'
+  attribution: 'no'

--- a/public/content/licenses/cc-by-sa.yml
+++ b/public/content/licenses/cc-by-sa.yml
@@ -1,0 +1,23 @@
+slug: cc-by-sa
+name: Creative Commons Attribution-ShareAlike 4.0
+short_name: CC BY-SA
+spdx: CC-BY-SA-4.0
+category: copyleft
+blurb: Free to use, modify, and redistribute — with attribution, and derivatives must use the same license.
+matchers:
+- cc by-sa
+- creative commons attribution-sharealike
+- cc-by-sa
+permissions:
+  commercial-static: 'yes'
+  commercial-web: 'yes'
+  commercial-app: 'yes'
+  commercial-server: 'yes'
+  open-source: 'yes'
+  modification: 'conditional'
+  redistribute: 'conditional'
+  standalone-sale: 'no'
+  embed-document: 'yes'
+  subsetting: 'conditional'
+  rename: 'conditional'
+  attribution: 'conditional'

--- a/public/content/licenses/free-use.yml
+++ b/public/content/licenses/free-use.yml
@@ -1,0 +1,22 @@
+slug: free-use
+name: Free Use License
+short_name: Free Use
+spdx: null
+category: permissive
+blurb: Free for personal and commercial use — typically no modification or redistribution rights.
+matchers:
+- free use
+- free-for-use
+permissions:
+  commercial-static: 'yes'
+  commercial-web: 'yes'
+  commercial-app: 'conditional'
+  commercial-server: 'conditional'
+  open-source: 'no'
+  modification: 'no'
+  redistribute: 'no'
+  standalone-sale: 'no'
+  embed-document: 'yes'
+  subsetting: 'conditional'
+  rename: 'no'
+  attribution: 'conditional'

--- a/public/content/licenses/freeware.yml
+++ b/public/content/licenses/freeware.yml
@@ -1,0 +1,21 @@
+slug: freeware
+name: Freeware License
+short_name: Freeware
+spdx: null
+category: permissive
+blurb: Free to download and use — but not open source. Modification and redistribution typically prohibited.
+matchers:
+- freeware
+permissions:
+  commercial-static: 'conditional'
+  commercial-web: 'conditional'
+  commercial-app: 'no'
+  commercial-server: 'no'
+  open-source: 'no'
+  modification: 'no'
+  redistribute: 'no'
+  standalone-sale: 'no'
+  embed-document: 'conditional'
+  subsetting: 'no'
+  rename: 'no'
+  attribution: 'conditional'

--- a/public/content/licenses/index.json
+++ b/public/content/licenses/index.json
@@ -153,6 +153,57 @@
     "examples": []
   },
   {
+    "slug": "free-use",
+    "name": "Free Use License",
+    "short_name": "Free Use",
+    "spdx": null,
+    "category": "permissive",
+    "blurb": "Free for personal and commercial use — typically no modification or redistribution rights.",
+    "matchers": [
+      "free use",
+      "free-for-use"
+    ],
+    "permissions": {
+      "commercial-static": "yes",
+      "commercial-web": "yes",
+      "commercial-app": "conditional",
+      "commercial-server": "conditional",
+      "open-source": "no",
+      "modification": "no",
+      "redistribute": "no",
+      "standalone-sale": "no",
+      "embed-document": "yes",
+      "subsetting": "conditional",
+      "rename": "no",
+      "attribution": "conditional"
+    }
+  },
+  {
+    "slug": "freeware",
+    "name": "Freeware License",
+    "short_name": "Freeware",
+    "spdx": null,
+    "category": "permissive",
+    "blurb": "Free to download and use — but not open source. Modification and redistribution typically prohibited.",
+    "matchers": [
+      "freeware"
+    ],
+    "permissions": {
+      "commercial-static": "conditional",
+      "commercial-web": "conditional",
+      "commercial-app": "no",
+      "commercial-server": "no",
+      "open-source": "no",
+      "modification": "no",
+      "redistribute": "no",
+      "standalone-sale": "no",
+      "embed-document": "conditional",
+      "subsetting": "no",
+      "rename": "no",
+      "attribution": "conditional"
+    }
+  },
+  {
     "slug": "gust",
     "name": "GUST Font Source License",
     "short_name": "GUST",
@@ -427,6 +478,61 @@
     ]
   },
   {
+    "slug": "public-domain",
+    "name": "Public Domain",
+    "short_name": "PD",
+    "spdx": "CC-PDDC",
+    "category": "public-domain",
+    "blurb": "No copyright restrictions — free for any purpose, including commercial use, modification, and redistribution.",
+    "matchers": [
+      "public domain",
+      "pd",
+      "unlicensed",
+      "copyright-free"
+    ],
+    "permissions": {
+      "commercial-static": "yes",
+      "commercial-web": "yes",
+      "commercial-app": "yes",
+      "commercial-server": "yes",
+      "open-source": "yes",
+      "modification": "yes",
+      "redistribute": "yes",
+      "standalone-sale": "yes",
+      "embed-document": "yes",
+      "subsetting": "yes",
+      "rename": "yes",
+      "attribution": "yes"
+    }
+  },
+  {
+    "slug": "cc-by-sa",
+    "name": "Creative Commons Attribution-ShareAlike 4.0",
+    "short_name": "CC BY-SA",
+    "spdx": "CC-BY-SA-4.0",
+    "category": "copyleft",
+    "blurb": "Free to use, modify, and redistribute — with attribution, and derivatives must use the same license.",
+    "matchers": [
+      "cc by-sa",
+      "creative commons attribution-sharealike",
+      "cc-by-sa"
+    ],
+    "permissions": {
+      "commercial-static": "yes",
+      "commercial-web": "yes",
+      "commercial-app": "yes",
+      "commercial-server": "yes",
+      "open-source": "yes",
+      "modification": "conditional",
+      "redistribute": "conditional",
+      "standalone-sale": "no",
+      "embed-document": "yes",
+      "subsetting": "conditional",
+      "rename": "conditional",
+      "attribution": "conditional"
+    }
+  },
+  {
     "slug": "gpl",
     "name": "GNU GPL (with font exception)",
     "short_name": "GPL",
@@ -499,5 +605,160 @@
         "note": "Red Hat's metrics-compatible Arial substitute"
       }
     ]
+  },
+  {
+    "slug": "adobe",
+    "name": "Adobe Software License",
+    "short_name": "Adobe",
+    "spdx": null,
+    "category": "special",
+    "blurb": "Fonts bundled with Adobe software — usable on any computer where the Adobe software is installed.",
+    "matchers": [
+      "adobe",
+      "acrobat"
+    ],
+    "permissions": {
+      "commercial-static": "conditional",
+      "commercial-web": "no",
+      "commercial-app": "no",
+      "commercial-server": "conditional",
+      "open-source": "no",
+      "modification": "no",
+      "redistribute": "no",
+      "standalone-sale": "no",
+      "embed-document": "conditional",
+      "subsetting": "no",
+      "rename": "no",
+      "attribution": "no"
+    }
+  },
+  {
+    "slug": "apple-only",
+    "name": "Apple Proprietary License",
+    "short_name": "Apple",
+    "spdx": null,
+    "category": "special",
+    "blurb": "Fonts bundled with macOS — may be used on macOS but not redistributed to other platforms.",
+    "matchers": [
+      "apple",
+      "macos"
+    ],
+    "permissions": {
+      "commercial-static": "conditional",
+      "commercial-web": "no",
+      "commercial-app": "no",
+      "commercial-server": "no",
+      "open-source": "no",
+      "modification": "no",
+      "redistribute": "no",
+      "standalone-sale": "no",
+      "embed-document": "conditional",
+      "subsetting": "no",
+      "rename": "no",
+      "attribution": "no"
+    }
+  },
+  {
+    "slug": "bundled",
+    "name": "Bundled Software License",
+    "short_name": "Bundled",
+    "spdx": null,
+    "category": "special",
+    "blurb": "Fonts bundled with commercial software — usage rights depend on the host software license.",
+    "matchers": [
+      "bundled"
+    ],
+    "permissions": {
+      "commercial-static": "conditional",
+      "commercial-web": "no",
+      "commercial-app": "no",
+      "commercial-server": "conditional",
+      "open-source": "no",
+      "modification": "no",
+      "redistribute": "no",
+      "standalone-sale": "no",
+      "embed-document": "conditional",
+      "subsetting": "no",
+      "rename": "no",
+      "attribution": "no"
+    }
+  },
+  {
+    "slug": "ms-office",
+    "name": "Microsoft Office Font License",
+    "short_name": "MS Office",
+    "spdx": null,
+    "category": "special",
+    "blurb": "Fonts bundled with Microsoft Office — usable on machines with a valid Office license.",
+    "matchers": [
+      "microsoft office",
+      "ms office",
+      "office fonts"
+    ],
+    "permissions": {
+      "commercial-static": "conditional",
+      "commercial-web": "no",
+      "commercial-app": "no",
+      "commercial-server": "conditional",
+      "open-source": "no",
+      "modification": "no",
+      "redistribute": "no",
+      "standalone-sale": "no",
+      "embed-document": "conditional",
+      "subsetting": "no",
+      "rename": "no",
+      "attribution": "no"
+    }
+  },
+  {
+    "slug": "microsoft-web",
+    "name": "Microsoft Web Fonts License",
+    "short_name": "MS Web",
+    "spdx": null,
+    "category": "special",
+    "blurb": "Microsoft web fonts — licensed for web embedding via CSS @font-face, not for desktop installation.",
+    "matchers": [
+      "microsoft web",
+      "ms web fonts"
+    ],
+    "permissions": {
+      "commercial-static": "no",
+      "commercial-web": "conditional",
+      "commercial-app": "no",
+      "commercial-server": "no",
+      "open-source": "no",
+      "modification": "no",
+      "redistribute": "no",
+      "standalone-sale": "no",
+      "embed-document": "conditional",
+      "subsetting": "no",
+      "rename": "no",
+      "attribution": "no"
+    }
+  },
+  {
+    "slug": "unknown",
+    "name": "Unknown License",
+    "short_name": "Unknown",
+    "spdx": null,
+    "category": "special",
+    "blurb": "License terms not specified or could not be determined — treat as all rights reserved.",
+    "matchers": [
+      "unknown"
+    ],
+    "permissions": {
+      "commercial-static": "conditional",
+      "commercial-web": "conditional",
+      "commercial-app": "conditional",
+      "commercial-server": "conditional",
+      "open-source": "conditional",
+      "modification": "conditional",
+      "redistribute": "conditional",
+      "standalone-sale": "conditional",
+      "embed-document": "conditional",
+      "subsetting": "conditional",
+      "rename": "conditional",
+      "attribution": "conditional"
+    }
   }
 ]

--- a/public/content/licenses/microsoft-web.yml
+++ b/public/content/licenses/microsoft-web.yml
@@ -1,0 +1,22 @@
+slug: microsoft-web
+name: Microsoft Web Fonts License
+short_name: MS Web
+spdx: null
+category: special
+blurb: Microsoft web fonts — licensed for web embedding via CSS @font-face, not for desktop installation.
+matchers:
+- microsoft web
+- ms web fonts
+permissions:
+  commercial-static: 'no'
+  commercial-web: 'conditional'
+  commercial-app: 'no'
+  commercial-server: 'no'
+  open-source: 'no'
+  modification: 'no'
+  redistribute: 'no'
+  standalone-sale: 'no'
+  embed-document: 'conditional'
+  subsetting: 'no'
+  rename: 'no'
+  attribution: 'no'

--- a/public/content/licenses/ms-office.yml
+++ b/public/content/licenses/ms-office.yml
@@ -1,0 +1,23 @@
+slug: ms-office
+name: Microsoft Office Font License
+short_name: MS Office
+spdx: null
+category: special
+blurb: Fonts bundled with Microsoft Office — usable on machines with a valid Office license.
+matchers:
+- microsoft office
+- ms office
+- office fonts
+permissions:
+  commercial-static: 'conditional'
+  commercial-web: 'no'
+  commercial-app: 'no'
+  commercial-server: 'conditional'
+  open-source: 'no'
+  modification: 'no'
+  redistribute: 'no'
+  standalone-sale: 'no'
+  embed-document: 'conditional'
+  subsetting: 'no'
+  rename: 'no'
+  attribution: 'no'

--- a/public/content/licenses/public-domain.yml
+++ b/public/content/licenses/public-domain.yml
@@ -1,0 +1,24 @@
+slug: public-domain
+name: Public Domain
+short_name: PD
+spdx: CC-PDDC
+category: public-domain
+blurb: No copyright restrictions — free for any purpose, including commercial use, modification, and redistribution.
+matchers:
+- public domain
+- pd
+- unlicensed
+- copyright-free
+permissions:
+  commercial-static: 'yes'
+  commercial-web: 'yes'
+  commercial-app: 'yes'
+  commercial-server: 'yes'
+  open-source: 'yes'
+  modification: 'yes'
+  redistribute: 'yes'
+  standalone-sale: 'yes'
+  embed-document: 'yes'
+  subsetting: 'yes'
+  rename: 'yes'
+  attribution: 'yes'

--- a/public/content/licenses/unknown.yml
+++ b/public/content/licenses/unknown.yml
@@ -1,0 +1,21 @@
+slug: unknown
+name: Unknown License
+short_name: Unknown
+spdx: null
+category: special
+blurb: License terms not specified or could not be determined — treat as all rights reserved.
+matchers:
+- unknown
+permissions:
+  commercial-static: 'conditional'
+  commercial-web: 'conditional'
+  commercial-app: 'conditional'
+  commercial-server: 'conditional'
+  open-source: 'conditional'
+  modification: 'conditional'
+  redistribute: 'conditional'
+  standalone-sale: 'conditional'
+  embed-document: 'conditional'
+  subsetting: 'conditional'
+  rename: 'conditional'
+  attribution: 'conditional'

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "MyWebSite",
-  "short_name": "MySite",
+  "name": "Fontist",
+  "short_name": "Fontist",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",
@@ -15,7 +15,7 @@
       "purpose": "maskable"
     }
   ],
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff",
+  "theme_color": "#f1ece1",
+  "background_color": "#f1ece1",
   "display": "standalone"
 }

--- a/src/components/FormulaBrowser.vue
+++ b/src/components/FormulaBrowser.vue
@@ -224,25 +224,29 @@ function toggleSource(value) {
 
 <template>
   <div class="formulas-browser">
-    <div class="search-container">
-      <input v-model="searchQuery" type="text" placeholder="Search fonts by name, family, or formula key..." class="search-input" />
-      <span class="result-count">{{ filteredFormulas.length }} formulas</span>
+    <div class="search-bar">
+      <input v-model="searchQuery" type="text" placeholder="Search fonts by name, family, or formula key…" class="search-input" />
+      <span class="result-count">{{ filteredFormulas.length.toLocaleString() }} formulas</span>
     </div>
 
     <div class="browser-layout">
       <aside class="filters-sidebar">
         <div class="filter-section">
-          <h4>License</h4>
-          <label v-for="opt in licenseOptions" :key="opt.value" class="filter-checkbox">
+          <h4 class="filter-heading">License</h4>
+          <label v-for="opt in licenseOptions" :key="opt.value" class="filter-checkbox" :class="{ on: selectedLicenses.includes(opt.value) }">
             <input type="checkbox" :checked="selectedLicenses.includes(opt.value)" @change="toggleLicense(opt.value)" />
-            <span class="filter-label"><span class="filter-icon" v-html="getLicenseIcon(opt.icon)"></span> {{ opt.label }} <span class="filter-count">({{ opt.count }})</span></span>
+            <span class="filter-icon" v-html="getLicenseIcon(opt.icon)"></span>
+            <span class="filter-text">{{ opt.label }}</span>
+            <span class="filter-count">{{ opt.count }}</span>
           </label>
         </div>
         <div class="filter-section">
-          <h4>Source</h4>
-          <label v-for="opt in sourceOptions" :key="opt.value" class="filter-checkbox">
+          <h4 class="filter-heading">Source</h4>
+          <label v-for="opt in sourceOptions" :key="opt.value" class="filter-checkbox" :class="{ on: selectedSources.includes(opt.value) }">
             <input type="checkbox" :checked="selectedSources.includes(opt.value)" @change="toggleSource(opt.value)" />
-            <span class="filter-label"><span class="filter-icon" v-html="getSourceIcon(opt.icon)"></span> {{ opt.label }} <span class="filter-count">({{ opt.count }})</span></span>
+            <span class="filter-icon" v-html="getSourceIcon(opt.icon)"></span>
+            <span class="filter-text">{{ opt.label }}</span>
+            <span class="filter-count">{{ opt.count }}</span>
           </label>
         </div>
       </aside>
@@ -257,14 +261,13 @@ function toggleSource(value) {
             <h3 class="letter-heading">{{ letter }}</h3>
             <div class="formula-items">
               <a v-for="f in groupedFormulas[letter]" :key="f.slug" :href="`/formulas/${f.slug}`" class="formula-item">
-                <div class="formula-main">
-                  <span class="formula-name">{{ f.name }}</span>
-                  <span class="formula-key">{{ f.formulaName }}</span>
-                </div>
-                <div class="formula-meta">
-                  <span class="formula-badges"><span :title="f.licenseName" v-html="getLicenseBadge(f)"></span> <span :title="f.sourceType" v-html="getSourceBadge(f)"></span></span>
-                  <span class="formula-counts">{{ f.familyCount }} {{ f.familyCount === 1 ? 'family' : 'families' }}, {{ f.styleCount }} {{ f.styleCount === 1 ? 'style' : 'styles' }}</span>
-                </div>
+                <span class="formula-name">{{ f.name }}</span>
+                <span class="formula-key">{{ f.formulaName }}</span>
+                <span class="formula-badges">
+                  <span :title="f.licenseName" v-html="getLicenseBadge(f)"></span>
+                  <span :title="f.sourceType" v-html="getSourceBadge(f)"></span>
+                </span>
+                <span class="formula-counts">{{ f.familyCount }} {{ f.familyCount === 1 ? 'family' : 'families' }} · {{ f.styleCount }} {{ f.styleCount === 1 ? 'style' : 'styles' }}</span>
               </a>
             </div>
           </div>
@@ -275,5 +278,248 @@ function toggleSource(value) {
 </template>
 
 <style scoped>
-/* All styles migrated to src/styles/main.css (@layer components). */
+.search-bar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--color-rule);
+  margin-bottom: 1.5rem;
+}
+
+.search-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--color-rule);
+  padding: 0.5rem 0;
+  font-family: var(--font-body);
+  font-size: 1rem;
+  color: var(--color-ink);
+  outline: none;
+  transition: border-color 0.2s;
+}
+.search-input:focus {
+  border-bottom-color: var(--color-accent);
+}
+.search-input::placeholder {
+  color: var(--color-mute);
+}
+
+.result-count {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-mute);
+  white-space: nowrap;
+}
+
+.browser-layout {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 2rem;
+}
+
+.filters-sidebar {
+  position: sticky;
+  top: 80px;
+  align-self: start;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  max-height: calc(100vh - 100px);
+  overflow-y: auto;
+}
+
+.filter-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.filter-heading {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--color-accent);
+  margin: 0 0 0.5rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--color-rule);
+}
+
+.filter-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0.4rem;
+  cursor: pointer;
+  border-radius: 2px;
+  transition: background 0.15s;
+}
+.filter-checkbox:hover {
+  background: var(--color-paper-deep);
+}
+.filter-checkbox.on {
+  background: var(--color-paper-deep);
+}
+.filter-checkbox input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+.filter-icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+}
+.filter-icon :deep(img) {
+  width: 16px;
+  height: 16px;
+}
+.filter-text {
+  font-family: var(--font-body);
+  font-size: 0.82rem;
+  color: var(--color-ink-soft);
+  flex: 1;
+}
+.filter-checkbox.on .filter-text {
+  color: var(--color-ink);
+  font-weight: 500;
+}
+.filter-count {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--color-mute);
+}
+
+.alpha-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.15rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--color-rule);
+  margin-bottom: 1rem;
+}
+
+.alpha-nav button {
+  background: transparent;
+  border: none;
+  width: 26px;
+  height: 26px;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--color-mute);
+  cursor: pointer;
+  border-radius: 2px;
+  transition: all 0.15s;
+}
+.alpha-nav button.has-content {
+  color: var(--color-ink-soft);
+}
+.alpha-nav button.has-content:hover {
+  background: var(--color-paper-deep);
+  color: var(--color-accent);
+}
+.alpha-nav button:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.letter-group {
+  margin-bottom: 1.5rem;
+}
+
+.letter-heading {
+  font-family: var(--font-display);
+  font-size: 1.3rem;
+  font-weight: 380;
+  font-style: italic;
+  color: var(--color-accent);
+  margin: 0 0 0.3rem;
+  padding-bottom: 0.3rem;
+  border-bottom: 1px solid var(--color-rule);
+}
+
+.formula-items {
+  display: flex;
+  flex-direction: column;
+}
+
+.formula-item {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.45rem 0;
+  text-decoration: none;
+  transition: padding 0.15s;
+}
+.formula-item:hover {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.formula-name {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  font-weight: 400;
+  color: var(--color-ink);
+  transition: color 0.2s;
+}
+.formula-item:hover .formula-name {
+  color: var(--color-accent);
+}
+
+.formula-key {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--color-mute);
+}
+
+.formula-badges {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+.formula-badges :deep(img) {
+  width: 18px;
+  height: 18px;
+}
+
+.formula-counts {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--color-mute);
+  white-space: nowrap;
+}
+
+@media (max-width: 800px) {
+  .browser-layout {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+  .filters-sidebar {
+    position: static;
+    max-height: none;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+  .filter-section {
+    flex: 1;
+    min-width: 200px;
+  }
+  .formula-item {
+    grid-template-columns: 1fr auto;
+    gap: 0.2rem 0.5rem;
+  }
+  .formula-key,
+  .formula-counts {
+    grid-column: 1 / -1;
+    font-size: 0.62rem;
+  }
+}
 </style>

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -91,7 +91,5 @@ const COLUMNS: { title: string; links: { label: string; to: string; external?: b
     <span class="sf-base-copy">© {year} Fontist · Ribose Ltd.</span>
     <span class="sf-base-sep" aria-hidden="true">·</span>
     <a href="https://github.com/fontist/fontist.org" class="sf-base-link">Source on GitHub</a>
-    <span class="sf-base-sep" aria-hidden="true">·</span>
-    <span class="sf-base-meta">Built with Astro + Vue islands</span>
   </div>
 </footer>

--- a/src/islands/FamiliesPage.vue
+++ b/src/islands/FamiliesPage.vue
@@ -1,34 +1,39 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { loadFontFamilies, type FontFamily } from '../lib/fonts/families-loader'
 
+const PAGE_SIZE = 50
 const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
 
 const allFamilies = ref<FontFamily[]>([])
 const searchQuery = ref('')
+const selectedCategory = ref('all')
 const selectedRedist = ref<'all' | 'redist' | 'proprietary'>('all')
-const selectedLicense = ref<string>('all')
-const licenseOptions = ref<{ value: string; label: string; count: number }[]>([
-  { value: 'all', label: 'All Licenses', count: 0 },
-])
+const currentPage = ref(1)
 
-// Top-level await: runs during SSG so the page ships with the family
-// list and license facets already populated. Query-param reads stay
-// here too — they pick up `?q=…&redist=…` from the route at render time.
+const CATEGORIES = [
+  { value: 'all', label: 'All' },
+  { value: 'open', label: 'Open Source' },
+  { value: 'free', label: 'Freely Distributable' },
+  { value: 'platform', label: 'Platform / Bundled' },
+  { value: 'other', label: 'Other / Unknown' },
+]
+
+function deriveCategory(f: FontFamily): string {
+  const name = (f.license_name || '').toLowerCase()
+  if (
+    name.includes('open font') || name.includes('ofl') ||
+    name.includes('apache') || name.includes('mit') ||
+    name.includes('cc0') || name.includes('public domain') ||
+    name.includes('bsd') || name.includes('ufl') || name.includes('ipa')
+  ) return 'open'
+  if (name.includes('freely') || name.includes('free use') || name.includes('freeware') || name.includes('gust')) return 'free'
+  if (name.includes('apple') || name.includes('microsoft') || name.includes('platform') || name.includes('office') || name.includes('adobe') || name.includes('bundled')) return 'platform'
+  return 'other'
+}
+
 const index = await loadFontFamilies()
 allFamilies.value = index.families
-
-const counts = new Map<string, number>()
-for (const f of index.families) {
-  const key = f.license_name || 'Unknown'
-  counts.set(key, (counts.get(key) ?? 0) + 1)
-}
-licenseOptions.value = [
-  { value: 'all', label: 'All Licenses', count: index.families.length },
-  ...[...counts.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .map(([value, count]) => ({ value, label: value, count })),
-]
 
 const q = (typeof window !== 'undefined' ? new URLSearchParams(window.location.search).get('q') : null)
 if (typeof q === 'string' && q) searchQuery.value = q
@@ -36,14 +41,13 @@ if (typeof q === 'string' && q) searchQuery.value = q
 const redist = (typeof window !== 'undefined' ? new URLSearchParams(window.location.search).get('redist') : null)
 if (redist === 'redist' || redist === 'proprietary') selectedRedist.value = redist
 
-const license = (typeof window !== 'undefined' ? new URLSearchParams(window.location.search).get('license') : null)
-if (
-  typeof license === 'string' &&
-  license &&
-  licenseOptions.value.some(o => o.value === license)
-) {
-  selectedLicense.value = license
-}
+const categoryCounts = computed(() => {
+  const counts: Record<string, number> = { all: allFamilies.value.length, open: 0, free: 0, platform: 0, other: 0 }
+  for (const f of allFamilies.value) {
+    counts[deriveCategory(f)]++
+  }
+  return counts
+})
 
 const filteredFamilies = computed(() => {
   let result = allFamilies.value
@@ -56,17 +60,24 @@ const filteredFamilies = computed(() => {
         f.formula_slugs.some(s => s.toLowerCase().includes(q)),
     )
   }
+  if (selectedCategory.value !== 'all') {
+    result = result.filter(f => deriveCategory(f) === selectedCategory.value)
+  }
   if (selectedRedist.value === 'redist') result = result.filter(f => f.redistributable)
   else if (selectedRedist.value === 'proprietary') result = result.filter(f => !f.redistributable)
-  if (selectedLicense.value !== 'all') {
-    result = result.filter(f => (f.license_name || 'Unknown') === selectedLicense.value)
-  }
   return [...result].sort((a, b) => a.name.localeCompare(b.name))
 })
 
-const groupedFamilies = computed(() => {
+const totalPages = computed(() => Math.max(1, Math.ceil(filteredFamilies.value.length / PAGE_SIZE)))
+
+const pagedFamilies = computed(() => {
+  const start = (currentPage.value - 1) * PAGE_SIZE
+  return filteredFamilies.value.slice(start, start + PAGE_SIZE)
+})
+
+const groupedPaged = computed(() => {
   const groups: Record<string, FontFamily[]> = {}
-  for (const f of filteredFamilies.value) {
+  for (const f of pagedFamilies.value) {
     const letter = f.name.charAt(0).toUpperCase()
     if (!groups[letter]) groups[letter] = []
     groups[letter].push(f)
@@ -75,73 +86,90 @@ const groupedFamilies = computed(() => {
 })
 
 const activeLetters = computed(() =>
-  alphabet.filter(letter => (groupedFamilies.value[letter]?.length ?? 0) > 0),
+  alphabet.filter(letter => (groupedPaged.value[letter]?.length ?? 0) > 0),
 )
+
+const showingFrom = computed(() =>
+  filteredFamilies.value.length === 0 ? 0 : (currentPage.value - 1) * PAGE_SIZE + 1,
+)
+const showingTo = computed(() =>
+  Math.min(currentPage.value * PAGE_SIZE, filteredFamilies.value.length),
+)
+
+watch([searchQuery, selectedCategory, selectedRedist], () => {
+  currentPage.value = 1
+})
 
 function scrollToLetter(letter: string) {
   const el = document.getElementById('letter-' + letter)
   if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
 }
 
+function goToPage(page: number) {
+  currentPage.value = page
+  const el = document.querySelector('.families-browser')
+  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+}
+
+const pageWindow = computed(() => {
+  const pages: number[] = []
+  const start = Math.max(1, currentPage.value - 2)
+  const end = Math.min(totalPages.value, currentPage.value + 2)
+  for (let i = start; i <= end; i++) pages.push(i)
+  return pages
+})
 </script>
 
 <template>
-  <div class="page-container">
-    <header class="fp-hero">
-      <h1>Font Families</h1>
-      <p class="fp-lede">
-        Every font family indexed by Fontist. One family may be shipped by multiple formulas — this
-        view groups them into a single canonical entry.
-      </p>
-    </header>
-
-    <div class="search-container">
+  <div class="families-browser">
+    <div class="search-bar">
       <input
         v-model="searchQuery"
         type="text"
         placeholder="Search by family name, slug, or formula…"
         class="search-input"
       />
-      <span class="result-count">{{ filteredFamilies.length }} families</span>
+      <span class="result-count">{{ filteredFamilies.length.toLocaleString() }} families</span>
     </div>
 
-    <div class="filters-row">
-      <div class="filter-group">
+    <div class="filters">
+      <div class="filter-row">
         <span class="filter-label">License</span>
-        <select v-model="selectedLicense" class="filter-select">
-          <option v-for="opt in licenseOptions" :key="opt.value" :value="opt.value">
-            {{ opt.label }} ({{ opt.count }})
-          </option>
-        </select>
-      </div>
-      <div class="filter-group">
-        <span class="filter-label">Redistributable</span>
         <div class="filter-chips">
           <button
-            :class="['chip', { on: selectedRedist === 'all' }]"
-            @click="selectedRedist = 'all'"
-          >All</button>
-          <button
-            :class="['chip', { on: selectedRedist === 'redist' }]"
-            @click="selectedRedist = 'redist'"
-          >Yes</button>
-          <button
-            :class="['chip', { on: selectedRedist === 'proprietary' }]"
-            @click="selectedRedist = 'proprietary'"
-          >No</button>
+            v-for="cat in CATEGORIES"
+            :key="cat.value"
+            :class="['chip', { on: selectedCategory === cat.value }]"
+            @click="selectedCategory = cat.value"
+          >
+            {{ cat.label }}
+            <span class="chip-count">{{ categoryCounts[cat.value] || 0 }}</span>
+          </button>
+        </div>
+      </div>
+      <div class="filter-row">
+        <span class="filter-label">Redistributable</span>
+        <div class="filter-chips">
+          <button :class="['chip', { on: selectedRedist === 'all' }]" @click="selectedRedist = 'all'">All</button>
+          <button :class="['chip', { on: selectedRedist === 'redist' }]" @click="selectedRedist = 'redist'">Yes</button>
+          <button :class="['chip', { on: selectedRedist === 'proprietary' }]" @click="selectedRedist = 'proprietary'">No</button>
         </div>
       </div>
     </div>
 
-    <nav class="alpha-nav">
+    <div class="alpha-nav">
       <button
         v-for="letter in alphabet"
         :key="letter"
-        :disabled="!groupedFamilies[letter]"
-        :class="{ 'has-content': groupedFamilies[letter] }"
+        :disabled="!groupedPaged[letter]"
+        :class="{ 'has-content': groupedPaged[letter] }"
         @click="scrollToLetter(letter)"
       >{{ letter }}</button>
-    </nav>
+    </div>
+
+    <div class="showing-info">
+      Showing {{ showingFrom.toLocaleString() }}–{{ showingTo.toLocaleString() }} of {{ filteredFamilies.length.toLocaleString() }} families
+    </div>
 
     <div class="family-list">
       <div
@@ -153,32 +181,314 @@ function scrollToLetter(letter: string) {
         <h3 class="letter-heading">{{ letter }}</h3>
         <div class="family-items">
           <a
-            v-for="f in groupedFamilies[letter]"
+            v-for="f in groupedPaged[letter]"
             :key="f.slug"
             :href="`/families/${f.slug}`"
             class="family-item"
           >
-            <div class="family-main">
-              <span class="family-name">{{ f.name }}</span>
-              <span class="family-meta">
-                {{ f.style_count }} {{ f.style_count === 1 ? 'style' : 'styles' }}
-                · {{ f.formula_slugs.length }} {{ f.formula_slugs.length === 1 ? 'formula' : 'formulas' }}
-              </span>
-            </div>
-            <div class="family-badges">
-              <span class="badge-license" :title="f.license_name">{{ f.license_name }}</span>
-              <span
-                :class="['badge-redist', { yes: f.redistributable }]"
-                :title="f.redistributable ? 'Redistributable' : 'Proprietary'"
-              >{{ f.redistributable ? '↯' : '⊘' }}</span>
-            </div>
+            <span class="family-name">{{ f.name }}</span>
+            <span class="family-meta">
+              {{ f.style_count }} {{ f.style_count === 1 ? 'style' : 'styles' }}
+              · {{ f.formula_slugs.length }} {{ f.formula_slugs.length === 1 ? 'formula' : 'formulas' }}
+            </span>
+            <span class="family-license" :title="f.license_name">{{ f.license_name }}</span>
+            <span
+              :class="['family-redist', { yes: f.redistributable }]"
+              :title="f.redistributable ? 'Redistributable' : 'Proprietary'"
+            >{{ f.redistributable ? '↯' : '⊘' }}</span>
           </a>
         </div>
       </div>
     </div>
+
+    <nav v-if="totalPages > 1" class="pagination">
+      <button class="page-btn" :disabled="currentPage === 1" @click="goToPage(currentPage - 1)">← Prev</button>
+      <button v-if="pageWindow[0] > 1" class="page-btn" @click="goToPage(1)">1</button>
+      <span v-if="pageWindow[0] > 2" class="page-ellipsis">…</span>
+      <button
+        v-for="page in pageWindow"
+        :key="page"
+        :class="['page-btn', { on: page === currentPage }]"
+        @click="goToPage(page)"
+      >{{ page }}</button>
+      <span v-if="pageWindow[pageWindow.length - 1] < totalPages - 1" class="page-ellipsis">…</span>
+      <button v-if="pageWindow[pageWindow.length - 1] < totalPages" class="page-btn" @click="goToPage(totalPages)">{{ totalPages }}</button>
+      <button class="page-btn" :disabled="currentPage === totalPages" @click="goToPage(currentPage + 1)">Next →</button>
+    </nav>
   </div>
 </template>
 
 <style scoped>
-/* All styles migrated to src/styles/main.css (@layer components). */
+.search-bar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--color-rule);
+  margin-bottom: 1.5rem;
+}
+
+.search-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--color-rule);
+  padding: 0.5rem 0;
+  font-family: var(--font-body);
+  font-size: 1rem;
+  color: var(--color-ink);
+  outline: none;
+  transition: border-color 0.2s;
+}
+.search-input:focus {
+  border-bottom-color: var(--color-accent);
+}
+.search-input::placeholder {
+  color: var(--color-mute);
+}
+
+.result-count {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-mute);
+  white-space: nowrap;
+}
+
+.filters {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.filter-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.filter-label {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--color-mute);
+  min-width: 90px;
+}
+
+.filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: transparent;
+  border: 1px solid var(--color-rule);
+  border-radius: 2px;
+  padding: 0.25rem 0.7rem;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-ink-soft);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.chip:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+.chip.on {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-paper);
+}
+
+.chip-count {
+  font-size: 0.6rem;
+  opacity: 0.7;
+}
+
+.alpha-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.15rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--color-rule);
+}
+
+.alpha-nav button {
+  background: transparent;
+  border: none;
+  width: 26px;
+  height: 26px;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--color-mute);
+  cursor: pointer;
+  border-radius: 2px;
+  transition: all 0.15s;
+}
+.alpha-nav button.has-content {
+  color: var(--color-ink-soft);
+}
+.alpha-nav button.has-content:hover {
+  background: var(--color-paper-deep);
+  color: var(--color-accent);
+}
+.alpha-nav button:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.showing-info {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--color-mute);
+  margin: 1rem 0;
+}
+
+.family-list {
+  min-height: 200px;
+}
+
+.letter-group {
+  margin-bottom: 1.5rem;
+}
+
+.letter-heading {
+  font-family: var(--font-display);
+  font-size: 1.3rem;
+  font-weight: 380;
+  font-style: italic;
+  color: var(--color-accent);
+  margin: 0 0 0.3rem;
+  padding-bottom: 0.3rem;
+  border-bottom: 1px solid var(--color-rule);
+}
+
+.family-items {
+  display: flex;
+  flex-direction: column;
+}
+
+.family-item {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding: 0.5rem 0;
+  text-decoration: none;
+  transition: padding 0.15s;
+}
+.family-item:hover {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.family-name {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  font-weight: 400;
+  color: var(--color-ink);
+  transition: color 0.2s;
+}
+.family-item:hover .family-name {
+  color: var(--color-accent);
+}
+
+.family-meta {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--color-mute);
+  white-space: nowrap;
+}
+
+.family-license {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-mute);
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.family-redist {
+  font-size: 0.9rem;
+  color: var(--color-mute);
+}
+.family-redist.yes {
+  color: var(--color-accent);
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  padding: 2rem 0;
+  border-top: 1px solid var(--color-rule);
+  margin-top: 1rem;
+  flex-wrap: wrap;
+}
+
+.page-btn {
+  background: transparent;
+  border: 1px solid var(--color-rule);
+  border-radius: 2px;
+  padding: 0.35rem 0.7rem;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--color-ink-soft);
+  cursor: pointer;
+  transition: all 0.15s;
+  min-width: 32px;
+}
+.page-btn:hover:not(:disabled):not(.on) {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+.page-btn.on {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-paper);
+}
+.page-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.page-ellipsis {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--color-mute);
+  padding: 0 0.3rem;
+}
+
+@media (max-width: 700px) {
+  .family-item {
+    grid-template-columns: 1fr auto;
+    gap: 0.3rem 0.5rem;
+  }
+  .family-meta {
+    grid-column: 1 / -1;
+    font-size: 0.65rem;
+  }
+  .family-license {
+    display: none;
+  }
+  .filter-label {
+    min-width: auto;
+  }
+}
 </style>

--- a/src/islands/HomePage.vue
+++ b/src/islands/HomePage.vue
@@ -15,8 +15,8 @@ import { fetchJson } from '../lib/ssr-fetch'
 
 const formulaCount = ref(0)
 const openSourceCount = ref(0)
-const openLicenseBuckets = ref<{ label: string; count: number; score: number }[]>([])
-const propLicenseBuckets = ref<{ label: string; count: number; score: number }[]>([])
+const openLicenseBuckets = ref<{ label: string; count: number; score: number; slug: string | null }[]>([])
+const propLicenseBuckets = ref<{ label: string; count: number; score: number; slug: string | null }[]>([])
 const recentPosts = ref<{ slug: string; title: string; date: string; description?: string }[]>([])
 
 async function loadStats() {
@@ -29,9 +29,9 @@ async function loadStats() {
     // backed by the YAML matchers in public/content/licenses/*.yml.
     const { open, proprietary } = await bucketFormulas(all)
 
-    const withScore = (list: { bucket: string; count: number }[]) => {
+    const withScore = (list: { bucket: string; count: number; slug: string | null }[]) => {
       const max = Math.max(...list.map(b => b.count), 1)
-      return list.map(b => ({ label: b.bucket, count: b.count, score: Math.round((b.count / max) * 100) }))
+      return list.map(b => ({ label: b.bucket, count: b.count, score: Math.round((b.count / max) * 100), slug: b.slug }))
     }
     openLicenseBuckets.value = withScore(open)
     propLicenseBuckets.value = withScore(proprietary)
@@ -275,19 +275,37 @@ onUnmounted(() => { if (typeTimer) clearTimeout(typeTimer) })
 
         <ul class="ll-list">
           <li v-for="b in openLicenseBuckets" :key="'open-' + b.label" class="ll-row ll-row--open">
-            <span class="ll-label">{{ b.label }}</span>
-            <span class="ll-bar-track" aria-hidden="true">
-              <span class="ll-bar-fill ll-bar-fill--open" :style="{ width: Math.max(2, b.score) + '%' }"></span>
-            </span>
-            <span class="ll-count">{{ b.count.toLocaleString() }}</span>
+            <a v-if="b.slug" :href="`/licenses/${b.slug}`" class="ll-link">
+              <span class="ll-label">{{ b.label }}</span>
+              <span class="ll-bar-track" aria-hidden="true">
+                <span class="ll-bar-fill ll-bar-fill--open" :style="{ width: Math.max(2, b.score) + '%' }"></span>
+              </span>
+              <span class="ll-count">{{ b.count.toLocaleString() }}</span>
+            </a>
+            <template v-else>
+              <span class="ll-label">{{ b.label }}</span>
+              <span class="ll-bar-track" aria-hidden="true">
+                <span class="ll-bar-fill ll-bar-fill--open" :style="{ width: Math.max(2, b.score) + '%' }"></span>
+              </span>
+              <span class="ll-count">{{ b.count.toLocaleString() }}</span>
+            </template>
           </li>
           <li class="ll-separator" aria-hidden="true"></li>
           <li v-for="b in propLicenseBuckets" :key="'prop-' + b.label" class="ll-row ll-row--prop">
-            <span class="ll-label">{{ b.label }}</span>
-            <span class="ll-bar-track" aria-hidden="true">
-              <span class="ll-bar-fill ll-bar-fill--prop" :style="{ width: Math.max(2, b.score) + '%' }"></span>
-            </span>
-            <span class="ll-count">{{ b.count.toLocaleString() }}</span>
+            <a v-if="b.slug" :href="`/licenses/${b.slug}`" class="ll-link">
+              <span class="ll-label">{{ b.label }}</span>
+              <span class="ll-bar-track" aria-hidden="true">
+                <span class="ll-bar-fill ll-bar-fill--prop" :style="{ width: Math.max(2, b.score) + '%' }"></span>
+              </span>
+              <span class="ll-count">{{ b.count.toLocaleString() }}</span>
+            </a>
+            <template v-else>
+              <span class="ll-label">{{ b.label }}</span>
+              <span class="ll-bar-track" aria-hidden="true">
+                <span class="ll-bar-fill ll-bar-fill--prop" :style="{ width: Math.max(2, b.score) + '%' }"></span>
+              </span>
+              <span class="ll-count">{{ b.count.toLocaleString() }}</span>
+            </template>
           </li>
         </ul>
 

--- a/src/layouts/DefaultLayout.astro
+++ b/src/layouts/DefaultLayout.astro
@@ -17,6 +17,11 @@ const currentPath = Astro.url.pathname
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#f1ece1" />
     <title>{title}</title>
     {description && <meta name="description" content={description} />}
     {canonical && <link rel="canonical" href={canonical} />}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -9,6 +9,11 @@ import SiteFooter from '../components/SiteFooter.astro'
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#f1ece1" />
     <title>Fontist</title>
     <script is:inline>
       (function(){try{var k='fontist-theme';var s=localStorage.getItem(k);var t=s==='light'||s==='dark'?s:(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');if(t==='dark')document.documentElement.classList.add('dark')}catch(e){}})();

--- a/src/pages/families.astro
+++ b/src/pages/families.astro
@@ -1,10 +1,22 @@
 ---
 import DefaultLayout from '../layouts/DefaultLayout.astro'
-import FamiliesPage from '../islands/FamiliesPage.vue'
+import FamiliesBrowser from '../islands/FamiliesPage.vue'
 
 const title = 'Font Families — Fontist'
+const description = 'Every font family indexed by Fontist — search, filter, and browse the full catalog of openly-licensed and platform-specific typefaces.'
 ---
 
-<DefaultLayout title={title}>
-  <FamiliesPage client:load />
+<DefaultLayout title={title} description={description} canonical="https://www.fontist.org/families">
+  <article class="mx-auto max-w-[1000px] px-6 pb-24 pt-[clamp(2.5rem,6vw,5rem)]">
+    <header class="mb-10">
+      <p class="mb-4 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-accent">Families</p>
+      <h1 class="font-display text-[clamp(2.4rem,6vw,3.8rem)] font-[360] italic leading-[1.02] tracking-[-0.025em] text-ink">Font Families</h1>
+      <p class="mt-5 max-w-[44em] font-display text-[clamp(1.1rem,1.8vw,1.3rem)] italic font-[380] leading-[1.5] text-ink-soft">
+        Every font family indexed by Fontist. One family may be shipped by multiple formulas — this view groups them into a single canonical entry.
+      </p>
+      <div class="mt-10 h-[2px] w-10 bg-accent" aria-hidden="true"></div>
+    </header>
+
+    <FamiliesBrowser client:load />
+  </article>
 </DefaultLayout>

--- a/src/pages/formulas/index.astro
+++ b/src/pages/formulas/index.astro
@@ -3,8 +3,20 @@ import DefaultLayout from '../../layouts/DefaultLayout.astro'
 import BrowsePage from '../../islands/BrowsePage.vue'
 
 const title = 'Formulas — Fontist'
+const description = 'Browse the full registry of Fontist formulas — installation recipes for thousands of openly-licensed and platform-specific font packages.'
 ---
 
-<DefaultLayout title={title}>
-  <BrowsePage client:load />
+<DefaultLayout title={title} description={description} canonical="https://www.fontist.org/formulas">
+  <article class="mx-auto max-w-[1100px] px-6 pb-24 pt-[clamp(2.5rem,6vw,5rem)]">
+    <header class="mb-10">
+      <p class="mb-4 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-accent">Formulas</p>
+      <h1 class="font-display text-[clamp(2.4rem,6vw,3.8rem)] font-[360] italic leading-[1.02] tracking-[-0.025em] text-ink">Font Formulas</h1>
+      <p class="mt-5 max-w-[44em] font-display text-[clamp(1.1rem,1.8vw,1.3rem)] italic font-[380] leading-[1.5] text-ink-soft">
+        The registry of installation recipes — each formula contains download instructions, checksums, and metadata for a font package. Search by name, filter by license or source.
+      </p>
+      <div class="mt-10 h-[2px] w-10 bg-accent" aria-hidden="true"></div>
+    </header>
+
+    <BrowsePage client:load />
+  </article>
 </DefaultLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -56,12 +56,6 @@ const instruments = [
   canonical="https://www.fontist.org/"
 >
   <div class="specimen">
-    <!-- Masthead -->
-    <div class="masthead">
-      <span class="c">A Specimen for Cross-Platform Font Management</span>
-      <span class="r">Vol. 01 / MMXXVI</span>
-    </div>
-
     <!-- Hero -->
     <section class="hero">
       <div class="ghost-numeral" aria-hidden="true">01</div>
@@ -282,11 +276,5 @@ const instruments = [
         </div>
       </div>
     </section>
-
-    <!-- Footer colophon -->
-    <footer class="foot">
-      <span>Set in <em>Spectral</em>, <em>IBM&nbsp;Plex</em>, &amp; <em>JetBrains&nbsp;Mono</em>.</span>
-      <span class="r">Fontist · a Ribose project · © MMXXVI</span>
-    </footer>
   </div>
 </DefaultLayout>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -882,6 +882,16 @@
     gap: 0.75rem;
     padding: 0.4rem 0;
   }
+  .ll-link {
+    display: grid;
+    grid-template-columns: minmax(180px, 1fr) minmax(120px, 2fr) 64px;
+    align-items: center;
+    gap: 0.75rem;
+    text-decoration: none;
+    transition: opacity 0.15s ease;
+  }
+  .ll-link:hover .ll-label { color: var(--color-accent); }
+  .ll-link:hover .ll-bar-fill { opacity: 1; }
   .ll-row--open  { border-bottom: 1px solid var(--color-rule); }
   .ll-row--prop  { border-bottom: 1px solid var(--color-rule); opacity: 0.78; }
   .ll-row--prop:last-of-type { border-bottom: none; }


### PR DESCRIPTION
## Summary

**Families page** — full restyle with editorial specimen-book aesthetic:
- Editorial header in .astro wrapper (kicker, italic Spectral display title, deck, accent rule mark) matching about/blog/guide pages
- Replaced the license dropdown (hundreds of entries) with 5 category chips: All, Open Source, Freely Distributable, Platform/Bundled, Other/Unknown — each with live count
- **Pagination** (50 families per page) with page window navigation — the page was unusable with 6,656 families all at once
- Showing X-Y of Z indicator, resets to page 1 on filter change
- Self-contained scoped styles

**Formulas page** — same editorial treatment:
- Editorial header (kicker, display title, deck, rule mark)
- FormulaBrowser restyled with sticky sidebar filters, editorial letter headings, accent hover effects, responsive layout
- Self-contained scoped styles

## Test plan

- [x] Build succeeds (63 pages)
- [x] Both pages have editorial headers in built HTML
- [x] FamiliesPage island includes pagination CSS
- [ ] CI passes