### PR TITLE
fix: guide content — invalid ::: containers, broken links

### DIFF
--- a/src/content/guide/choosing-formula.mdx
+++ b/src/content/guide/choosing-formula.mdx
@@ -41,9 +41,7 @@ For automated document generation in pipelines:
 
 ### Open Source (Recommended)
 
-::: tip Best for most use cases
-Open source licenses provide the most flexibility for all use cases.
-:::
+> **Tip — Best for most use cases.** Open source licenses provide the most flexibility for all use cases.
 
 | License | Formulas | Use Cases |
 |---------|----------|-----------|
@@ -53,9 +51,7 @@ Open source licenses provide the most flexibility for all use cases.
 
 ### Platform Restricted
 
-::: warning License compliance required
-These fonts are only legal on specific platforms.
-:::
+> **Warning — License compliance required.** These fonts are only legal on specific platforms.
 
 | License | Platform | Cloud Options |
 |---------|----------|---------------|

--- a/src/content/guide/create-formula.mdx
+++ b/src/content/guide/create-formula.mdx
@@ -17,6 +17,6 @@ You may need to change it manually when:
 
 - the script could not detect proper license text
 - you would like to change a name of a formula (may use the `--name` option)
-- the archive is private (see [private-formula-authentication](/formulas/guide/private-repositories#private-formula-authentication))
+- the archive is private (see [private-formula-authentication](/guide/private-repositories#private-formula-authentication))
 
 The formula can be proposed to be merged to [the main repository](https://github.com/fontist/formulas), or added to a private repository.

--- a/src/content/guide/formula-structure.mdx
+++ b/src/content/guide/formula-structure.mdx
@@ -190,6 +190,6 @@ open_license: |
 
 ## See Also
 
-- [What is a Formula?](/formulas/guide/what-is-formula)
-- [Choosing a Formula](/formulas/guide/choosing-formula)
-- [Create a Formula](/formulas/guide/create-formula)
+- [What is a Formula?](/guide/what-is-formula)
+- [Choosing a Formula](/guide/choosing-formula)
+- [Create a Formula](/guide/create-formula)

--- a/src/content/guide/use-cases/cloud-vms.mdx
+++ b/src/content/guide/use-cases/cloud-vms.mdx
@@ -145,12 +145,10 @@ steps:
 | macOS VMs | Apple fonts, open source |
 | GitHub Actions macOS | Apple fonts, open source |
 
-::: warning
-Apple-only fonts are only legal on Apple-branded hardware. GitHub Actions and MacStadium provide legitimate macOS VMs.
-:::
+> **Warning.** Apple-only fonts are only legal on Apple-branded hardware. GitHub Actions and MacStadium provide legitimate macOS VMs.
 
 ## See Also
 
-- [CI/CD & Servers](/formulas/guide/use-cases/server-side)
-- [Docker & Containers](/formulas/guide/use-cases/containerized)
-- [Apple-only License](/formulas/licenses/apple-only)
+- [CI/CD & Servers](/guide/use-cases/server-side)
+- [Docker & Containers](/guide/use-cases/containerized)
+- [Apple-only License](/licenses/apple-only)

--- a/src/content/guide/use-cases/containerized.mdx
+++ b/src/content/guide/use-cases/containerized.mdx
@@ -173,5 +173,5 @@ Mount `~/.fontist` as a volume to avoid reinstalling.
 
 ## See Also
 
-- [CI/CD & Servers](/formulas/guide/use-cases/server-side)
-- [PDF Generation](/formulas/guide/use-cases/pdf-generation)
+- [CI/CD & Servers](/guide/use-cases/server-side)
+- [PDF Generation](/guide/use-cases/pdf-generation)

--- a/src/content/guide/use-cases/desktop-publishing.mdx
+++ b/src/content/guide/use-cases/desktop-publishing.mdx
@@ -35,9 +35,7 @@ fontist status "Open Sans"
 2. **Restart InDesign** to detect new fonts
 3. **Use fonts** in your documents
 
-::: tip
-Fontist installs fonts to `~/.fontist/fonts/` by default. Some applications may need to be configured to use this directory.
-:::
+> **Tip.** Fontist installs fonts to `~/.fontist/fonts/` by default. Some applications may need to be configured to use this directory.
 
 ### Scribus
 
@@ -83,5 +81,5 @@ Most licenses allow subsetting when embedding in PDFs. OFL 1.1 explicitly permit
 
 ## See Also
 
-- [Choosing a Formula](/formulas/guide/choosing-formula)
-- [License Overview](/formulas/licenses/)
+- [Choosing a Formula](/guide/choosing-formula)
+- [License Overview](/licenses/)

--- a/src/content/guide/use-cases/document-generation.mdx
+++ b/src/content/guide/use-cases/document-generation.mdx
@@ -116,5 +116,5 @@ In CI, cache `~/.fontist/` between runs.
 
 ## See Also
 
-- [CI/CD & Servers](/formulas/guide/use-cases/server-side)
-- [PDF Generation](/formulas/guide/use-cases/pdf-generation)
+- [CI/CD & Servers](/guide/use-cases/server-side)
+- [PDF Generation](/guide/use-cases/pdf-generation)

--- a/src/content/guide/use-cases/pdf-generation.mdx
+++ b/src/content/guide/use-cases/pdf-generation.mdx
@@ -124,5 +124,5 @@ Most open source licenses allow embedding. Check the license page for details.
 
 ## See Also
 
-- [Document Generation](/formulas/guide/use-cases/document-generation)
-- [CI/CD & Servers](/formulas/guide/use-cases/server-side)
+- [Document Generation](/guide/use-cases/document-generation)
+- [CI/CD & Servers](/guide/use-cases/server-side)

--- a/src/content/guide/use-cases/server-side.mdx
+++ b/src/content/guide/use-cases/server-side.mdx
@@ -137,6 +137,6 @@ fontist install "open_sans"
 
 ## See Also
 
-- [Docker & Containers](/formulas/guide/use-cases/containerized)
-- [Cloud VMs](/formulas/guide/use-cases/cloud-vms)
+- [Docker & Containers](/guide/use-cases/containerized)
+- [Cloud VMs](/guide/use-cases/cloud-vms)
 - [GitHub Actions Integration](https://github.com/fontist/setup-fontist)

--- a/src/content/guide/use-cases/web-development.mdx
+++ b/src/content/guide/use-cases/web-development.mdx
@@ -83,5 +83,5 @@ Use Fontist when you need to:
 
 ## See Also
 
-- [Choosing a Formula](/formulas/guide/choosing-formula)
-- [OFL License](/formulas/licenses/ofl)
+- [Choosing a Formula](/guide/choosing-formula)
+- [OFL License](/licenses/ofl)

--- a/src/content/guide/what-is-formula.mdx
+++ b/src/content/guide/what-is-formula.mdx
@@ -112,6 +112,6 @@ fontist install "open_sans" --style "Bold"
 
 ## See Also
 
-- [Formula Structure](/formulas/guide/formula-structure) - Detailed YAML structure
-- [Choosing a Formula](/formulas/guide/choosing-formula) - How to pick the right one
-- [Create a Formula](/formulas/guide/create-formula) - Make your own formula
+- [Formula Structure](/guide/formula-structure) - Detailed YAML structure
+- [Choosing a Formula](/guide/choosing-formula) - How to pick the right one
+- [Create a Formula](/guide/create-formula) - Make your own formula


### PR DESCRIPTION
## Summary

Three content issues fixed across guide MDX files:

1. **VitePress containers** — `::: tip` and `::: warning` directives are not valid MDX, rendered as literal text. Converted to blockquotes with bold labels.

2. **Broken guide links** — Internal links used `/formulas/guide/` prefix instead of `/guide/`. Fixed across all guide files.

3. **Broken license links** — Links used `/formulas/licenses/` instead of `/licenses/`. Fixed in desktop-publishing, web-development, cloud-vms.

## Test plan

- [x] Build succeeds
- [x] No remaining `:::` directives in content
- [x] No remaining `/formulas/guide/` or `/formulas/licenses/` links
- [ ] CI passes