### PR TITLE
fix: deduplicate formulas by name + two-line editorial item redesign

### DIFF
--- a/src/components/FormulaBrowser.vue
+++ b/src/components/FormulaBrowser.vue
@@ -179,7 +179,25 @@ const filteredFormulas = computed(() => {
   if (!selectedSources.value.includes('all')) {
     result = result.filter(f => selectedSources.value.includes(f.sourceType))
   }
-  return result.sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+  result = result.sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+
+  // Deduplicate by name: many formulas (different macOS font packages)
+  // share the same font name. Group them, pick the primary formula
+  // (most styles), and track how many formulas provide this font.
+  const byName = new Map()
+  for (const f of result) {
+    const key = (f.name || '').toLowerCase()
+    if (!byName.has(key)) {
+      byName.set(key, { ...f, _formulaCount: 1 })
+    } else {
+      const existing = byName.get(key)
+      existing._formulaCount++
+      if ((f.styleCount || 0) > (existing.styleCount || 0)) {
+        byName.set(key, { ...f, _formulaCount: existing._formulaCount })
+      }
+    }
+  }
+  return [...byName.values()]
 })
 
 const groupedFormulas = computed(() => {
@@ -300,13 +318,18 @@ function toggleSource(value) {
             <h3 class="letter-heading">{{ letter }}</h3>
             <div class="formula-items">
               <a v-for="f in groupedFormulas[letter]" :key="f.slug" :href="`/formulas/${f.slug}`" class="formula-item">
-                <span class="formula-name">{{ f.name }}</span>
-                <span class="formula-key">{{ f.formulaName }}</span>
-                <span class="formula-badges">
-                  <span :title="f.licenseName" v-html="getLicenseBadge(f)"></span>
-                  <span :title="f.sourceType" v-html="getSourceBadge(f)"></span>
-                </span>
-                <span class="formula-counts">{{ f.familyCount }} {{ f.familyCount === 1 ? 'family' : 'families' }} · {{ f.styleCount }} {{ f.styleCount === 1 ? 'style' : 'styles' }}</span>
+                <div class="formula-line1">
+                  <span class="formula-name">{{ f.name }}</span>
+                  <span v-if="f._formulaCount > 1" class="formula-dupe" :title="f._formulaCount + ' formulas provide this font'">+{{ f._formulaCount - 1 }}</span>
+                  <span class="formula-badges">
+                    <span :title="f.licenseName" v-html="getLicenseBadge(f)"></span>
+                    <span :title="f.sourceType" v-html="getSourceBadge(f)"></span>
+                  </span>
+                </div>
+                <div class="formula-line2">
+                  <span class="formula-key">{{ f.formulaName }}</span>
+                  <span class="formula-counts">{{ f.familyCount }} {{ f.familyCount === 1 ? 'family' : 'families' }} · {{ f.styleCount }} {{ f.styleCount === 1 ? 'style' : 'styles' }}</span>
+                </div>
               </a>
             </div>
           </div>
@@ -510,28 +533,71 @@ function toggleSource(value) {
 }
 
 .formula-item {
-  display: grid;
-  grid-template-columns: 1fr auto auto auto;
-  align-items: baseline;
-  gap: 0.75rem;
-  padding: 0.55rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.6rem 0;
   text-decoration: none;
   transition: padding 0.15s;
+  border-bottom: 1px solid transparent;
 }
 .formula-item:hover {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
+  border-bottom-color: var(--color-rule);
+}
+
+.formula-line1 {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.formula-line2 {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding-left: 0.1rem;
 }
 
 .formula-name {
   font-family: var(--font-display);
-  font-size: 1rem;
+  font-size: 1.05rem;
   font-weight: 400;
   color: var(--color-ink);
   transition: color 0.2s;
+  flex: 1;
 }
 .formula-item:hover .formula-name {
   color: var(--color-accent);
+}
+
+.formula-dupe {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  font-weight: 600;
+  color: var(--color-accent);
+  background: var(--color-paper-deep);
+  padding: 0.1rem 0.35rem;
+  border-radius: 2px;
+  line-height: 1.2;
+  flex-shrink: 0;
+}
+
+.formula-badges {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  opacity: 0.65;
+  transition: opacity 0.2s;
+  flex-shrink: 0;
+}
+.formula-item:hover .formula-badges {
+  opacity: 1;
+}
+.formula-badges :deep(img) {
+  width: 16px;
+  height: 16px;
 }
 
 .formula-key {
@@ -540,25 +606,11 @@ function toggleSource(value) {
   color: var(--color-mute);
 }
 
-.formula-badges {
-  display: flex;
-  align-items: center;
-  gap: 0.3rem;
-  opacity: 0.7;
-  transition: opacity 0.2s;
-}
-.formula-item:hover .formula-badges {
-  opacity: 1;
-}
-.formula-badges :deep(img) {
-  width: 18px;
-  height: 18px;
-}
-
 .formula-counts {
   font-family: var(--font-mono);
   font-size: 0.68rem;
   color: var(--color-mute);
+  margin-left: auto;
   white-space: nowrap;
 }
 
@@ -631,13 +683,17 @@ function toggleSource(value) {
     min-width: 200px;
   }
   .formula-item {
-    grid-template-columns: 1fr auto;
-    gap: 0.2rem 0.5rem;
+    padding: 0.5rem 0;
+  }
+  .formula-name {
+    font-size: 0.95rem;
   }
   .formula-key,
   .formula-counts {
-    grid-column: 1 / -1;
     font-size: 0.62rem;
+  }
+  .formula-dupe {
+    font-size: 0.55rem;
   }
 }
 </style>

--- a/src/islands/FamiliesPage.vue
+++ b/src/islands/FamiliesPage.vue
@@ -186,16 +186,20 @@ const pageWindow = computed(() => {
             :href="`/families/${f.slug}`"
             class="family-item"
           >
-            <span class="family-name">{{ f.name }}</span>
-            <span class="family-meta">
-              {{ f.style_count }} {{ f.style_count === 1 ? 'style' : 'styles' }}
-              · {{ f.formula_slugs.length }} {{ f.formula_slugs.length === 1 ? 'formula' : 'formulas' }}
-            </span>
-            <span class="family-license" :title="f.license_name">{{ f.license_name }}</span>
-            <span
-              :class="['family-redist', { yes: f.redistributable }]"
-              :title="f.redistributable ? 'Redistributable' : 'Proprietary'"
-            >{{ f.redistributable ? '↯' : '⊘' }}</span>
+            <div class="family-line1">
+              <span class="family-name">{{ f.name }}</span>
+              <span
+                :class="['family-redist', { yes: f.redistributable }]"
+                :title="f.redistributable ? 'Redistributable' : 'Proprietary'"
+              >{{ f.redistributable ? '↯' : '⊘' }}</span>
+            </div>
+            <div class="family-line2">
+              <span class="family-meta">
+                {{ f.style_count }} {{ f.style_count === 1 ? 'style' : 'styles' }}
+                · {{ f.formula_slugs.length }} {{ f.formula_slugs.length === 1 ? 'formula' : 'formulas' }}
+              </span>
+              <span class="family-license" :title="f.license_name">{{ f.license_name }}</span>
+            </div>
           </a>
         </div>
       </div>
@@ -380,25 +384,40 @@ const pageWindow = computed(() => {
 }
 
 .family-item {
-  display: grid;
-  grid-template-columns: 1fr auto auto auto;
-  align-items: baseline;
-  gap: 0.75rem;
-  padding: 0.5rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.6rem 0;
   text-decoration: none;
   transition: padding 0.15s;
+  border-bottom: 1px solid transparent;
 }
 .family-item:hover {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
+  border-bottom-color: var(--color-rule);
+}
+
+.family-line1 {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.family-line2 {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding-left: 0.1rem;
 }
 
 .family-name {
   font-family: var(--font-display);
-  font-size: 1rem;
+  font-size: 1.05rem;
   font-weight: 400;
   color: var(--color-ink);
   transition: color 0.2s;
+  flex: 1;
 }
 .family-item:hover .family-name {
   color: var(--color-accent);
@@ -406,7 +425,7 @@ const pageWindow = computed(() => {
 
 .family-meta {
   font-family: var(--font-mono);
-  font-size: 0.72rem;
+  font-size: 0.68rem;
   color: var(--color-mute);
   white-space: nowrap;
 }
@@ -417,7 +436,8 @@ const pageWindow = computed(() => {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--color-mute);
-  max-width: 200px;
+  margin-left: auto;
+  max-width: 240px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -426,6 +446,7 @@ const pageWindow = computed(() => {
 .family-redist {
   font-size: 0.9rem;
   color: var(--color-mute);
+  flex-shrink: 0;
 }
 .family-redist.yes {
   color: var(--color-accent);
@@ -477,12 +498,13 @@ const pageWindow = computed(() => {
 
 @media (max-width: 700px) {
   .family-item {
-    grid-template-columns: 1fr auto;
-    gap: 0.3rem 0.5rem;
+    padding: 0.5rem 0;
+  }
+  .family-name {
+    font-size: 0.95rem;
   }
   .family-meta {
-    grid-column: 1 / -1;
-    font-size: 0.65rem;
+    font-size: 0.62rem;
   }
   .family-license {
     display: none;


### PR DESCRIPTION
## Summary

**Duplicate fix:** 4283 formulas included 1750 duplicate-name entries (e.g. "Al Bayan" appeared 6 times from different macOS font packages providing the same font). Now deduplicates by name to 2533 unique entries. Shows "+N" badge when multiple formulas provide the same font, linking to the formula with the most styles.

**Item redesign (both pages):** Changed from single-line grid to two-line flex column layout:
- **Line 1:** Name (display serif 1.05rem, flex:1) + badges/symbols (right-aligned)
- **Line 2:** Formula key / family metadata (mono, muted)
- Hover: padding shift + accent name color + bottom border
- More presence and breathing room per entry — feels like a specimen catalog, not a data table

Both formulas and families pages now use identical item layout patterns.

## Test plan

- [x] Build succeeds (63 pages)
- [x] No more duplicate "Al Bayan" entries — shows once with +N badge
- [ ] CI passes