### PR TITLE
fix: enrich font metadata with woff paths + add unicode block SPA route

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "scripts": {
     "dev": "astro dev",
-    "build": "bash scripts/fetch-data.sh && node scripts/gen-font-families.mjs && node scripts/gen-licenses-index.mjs && node scripts/gen-blog-index.mjs && node scripts/gen-guide-index.mjs && astro build && node scripts/gen-sitemap.mjs",
-    "build:no-fetch": "node scripts/gen-font-families.mjs && node scripts/gen-licenses-index.mjs && node scripts/gen-blog-index.mjs && node scripts/gen-guide-index.mjs && astro build && node scripts/gen-sitemap.mjs",
+    "build": "bash scripts/fetch-data.sh && node scripts/enrich-font-metadata.mjs && node scripts/gen-font-families.mjs && node scripts/gen-licenses-index.mjs && node scripts/gen-blog-index.mjs && node scripts/gen-guide-index.mjs && astro build && node scripts/gen-sitemap.mjs",
+    "build:no-fetch": "node scripts/enrich-font-metadata.mjs && node scripts/gen-font-families.mjs && node scripts/gen-licenses-index.mjs && node scripts/gen-blog-index.mjs && node scripts/gen-guide-index.mjs && astro build && node scripts/gen-sitemap.mjs",
     "preview": "astro preview",
     "fetch-data": "bash scripts/fetch-data.sh",
     "gen-routes": "node scripts/gen-blog-index.mjs && node scripts/gen-guide-index.mjs ",

--- a/scripts/enrich-font-metadata.mjs
+++ b/scripts/enrich-font-metadata.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Enriches public/font-metadata.json by scanning public/woff/ for actual
+// woff files and populating the woff_file + coverage_file fields for each
+// redistributable font that has one.
+//
+// The upstream fontist-archive-public metadata only has woff_file for ~6
+// of 16,432 fonts. This script fills the gap by matching font slugs to
+// the actual woff files that exist in public/woff/.
+//
+// Run after fetch-data.sh, before gen-font-families.mjs.
+
+import { readFileSync, writeFileSync, readdirSync, existsSync, statSync } from 'node:fs'
+import { resolve, dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const PUBLIC = resolve(ROOT, 'public')
+
+const metaPath = resolve(PUBLIC, 'font-metadata.json')
+const woffDir = resolve(PUBLIC, 'woff')
+const coverageDir = resolve(PUBLIC, 'coverage')
+
+const meta = JSON.parse(readFileSync(metaPath, 'utf8'))
+const fonts = meta.fonts || []
+console.log(`font-metadata: ${fonts.length} entries`)
+
+// Build woff index: { slug → woff_path }
+// Scans both flat (woff/{source}/{slug}.woff) and nested
+// (woff/{source}/{slug}/{PSName}.woff) patterns.
+const woffIndex = new Map()
+
+if (existsSync(woffDir)) {
+  for (const source of readdirSync(woffDir)) {
+    const sourceDir = join(woffDir, source)
+    if (!statSync(sourceDir).isDirectory()) continue
+
+    for (const entry of readdirSync(sourceDir)) {
+      const fullPath = join(sourceDir, entry)
+      if (entry.endsWith('.woff') && statSync(fullPath).isFile()) {
+        // Flat: woff/{source}/{slug}.woff
+        const slug = entry.replace(/\.woff$/, '')
+        woffIndex.set(slug, `woff/${source}/${entry}`)
+      } else if (statSync(fullPath).isDirectory()) {
+        // Nested: woff/{source}/{slug}/{PSName}.woff
+        const slug = entry
+        for (const file of readdirSync(fullPath)) {
+          if (file.endsWith('.woff')) {
+            const psName = file.replace(/\.woff$/, '')
+            // Prefer the first woff found for the slug
+            if (!woffIndex.has(slug)) {
+              woffIndex.set(slug, `woff/${source}/${slug}/${file}`)
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+console.log(`woff index: ${woffIndex.size} files found`)
+
+// Build coverage index: { slug → coverage_path }
+const coverageIndex = new Map()
+if (existsSync(coverageDir)) {
+  // Flat coverage files: coverage/{slug}.json
+  for (const entry of readdirSync(coverageDir)) {
+    if (entry.endsWith('.json')) {
+      const slug = entry.replace(/\.json$/, '')
+      coverageIndex.set(slug, `coverage/${entry}`)
+    }
+  }
+  // Nested: coverage/{source}/{slug}/...
+  for (const source of readdirSync(coverageDir)) {
+    const sourceDir = join(coverageDir, source)
+    if (!statSync(sourceDir).isDirectory()) continue
+    for (const slugDir of readdirSync(sourceDir)) {
+      const slugPath = join(sourceDir, slugDir)
+      if (!statSync(slugPath).isDirectory()) continue
+      if (!coverageIndex.has(slugDir)) {
+        coverageIndex.set(slugDir, `coverage/${source}/${slugDir}`)
+      }
+    }
+  }
+}
+
+console.log(`coverage index: ${coverageIndex.size} entries`)
+
+// Enrich metadata
+let woffAdded = 0
+let coverageAdded = 0
+for (const font of fonts) {
+  if (!font.woff_file && woffIndex.has(font.slug)) {
+    font.woff_file = woffIndex.get(font.slug)
+    woffAdded++
+  }
+  if (!font.coverage_file && coverageIndex.has(font.slug)) {
+    font.coverage_file = coverageIndex.get(font.slug)
+    coverageAdded++
+  }
+}
+
+console.log(`Enriched: ${woffAdded} woff_file, ${coverageAdded} coverage_file`)
+console.log(`Total with woff_file: ${fonts.filter(f => f.woff_file).length} / ${fonts.length}`)
+
+writeFileSync(metaPath, JSON.stringify(meta, null, 2) + '\n')
+console.log(`Updated ${metaPath}`)

--- a/scripts/enrich-font-metadata.mjs
+++ b/scripts/enrich-font-metadata.mjs
@@ -21,6 +21,11 @@ const metaPath = resolve(PUBLIC, 'font-metadata.json')
 const woffDir = resolve(PUBLIC, 'woff')
 const coverageDir = resolve(PUBLIC, 'coverage')
 
+if (!existsSync(metaPath)) {
+  console.log('font-metadata.json not found — skipping enrichment')
+  process.exit(0)
+}
+
 const meta = JSON.parse(readFileSync(metaPath, 'utf8'))
 const fonts = meta.fonts || []
 console.log(`font-metadata: ${fonts.length} entries`)

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -33,6 +33,7 @@ import SiteFooter from '../components/SiteFooter.astro'
       import FontFamilyPage from '../islands/FontFamilyPage.vue'
       import FontFamilyUnicodePage from '../islands/FontFamilyUnicodePage.vue'
       import UnicodeCharPage from '../islands/UnicodeCharPage.vue'
+      import UnicodeBlockPage from '../islands/UnicodeBlockPage.vue'
       import FontBlockCoveragePage from '../islands/FontBlockCoveragePage.vue'
       import PropertyDetailPage from '../islands/PropertyDetailPage.vue'
 
@@ -46,6 +47,7 @@ import SiteFooter from '../components/SiteFooter.astro'
         { match: /^\/families\/([^/]+)\/?$/,       Comp: FontFamilyPage,        getProps: m => ({ familySlug: m[1] }) },
         { match: /^\/families\/([^/]+)\/unicode\/?$/, Comp: FontFamilyUnicodePage, getProps: m => ({ familySlug: m[1] }) },
         { match: /^\/unicode\/char\/([^/]+)\/?$/,  Comp: UnicodeCharPage,       getProps: m => ({ hex: m[1] }) },
+        { match: /^\/unicode\/block\/([^/]+)\/?$/, Comp: UnicodeBlockPage,      getProps: m => ({ blockSlug: m[1] }) },
         { match: /^\/fonts\/([^/]+)\/unicode\/block\/([^/]+)\/?$/, Comp: FontBlockCoveragePage, getProps: m => ({ fontSlug: m[1], blockSlug: m[2] }) },
         { match: /^\/unicode\/(scripts|category|combining|bidiclass)\/([^/]+)\/?$/, Comp: PropertyDetailPage, getProps: m => ({ property: m[1], title: {scripts:'Script',category:'Category',combining:'Combining Class',bidiclass:'Bidirectional Class'}[m[1]], code: m[2] }) },
       ]


### PR DESCRIPTION
## Summary

**1. Font metadata enrichment (woff_file population)**

The upstream `fontist-archive-public` metadata only has `woff_file` for 6 of 16,432 fonts. This means family pages like `/families/actor` couldn't load the actual font for preview even though `woff/google/actor.woff` exists.

Created `scripts/enrich-font-metadata.mjs` that:
- Scans `public/woff/` for all actual woff files (flat and nested patterns)
- Matches them to metadata entries by slug
- Populates `woff_file` and `coverage_file` fields
- Result: **1,663 fonts** now have woff paths (up from 6)

Added to the build pipeline (`build` and `build:no-fetch`) before `gen-font-families.mjs` so `font-families.json` gets the correct paths.

**2. Unicode block SPA route**

`/unicode/block/tags` (and all other block pages) were 404 because the SPA fallback routing in `404.astro` had no route for `/unicode/block/{slug}` — it only had `/fonts/{slug}/unicode/block/{block}`. Added `UnicodeBlockPage` import and route.

## Test plan

- [x] Build succeeds (63 pages)
- [x] `/families/actor` — `font-families.json` now has `path: "woff/google/actor.woff"`
- [x] SPA route for `/unicode/block/{slug}` in bundled JS
- [ ] CI passes