### PR TITLE
feat: paginate Unicode block pages — 512 chars per page

### DIFF
--- a/src/islands/UnicodeBlockPage.vue
+++ b/src/islands/UnicodeBlockPage.vue
@@ -6,6 +6,8 @@ import UnicodeBlockGrid from '../lib/unicode/components/UnicodeBlockGrid.vue'
 import type { FontContext } from '../lib/types/domain'
 import { resolveFontContexts, parseFontSlugsFromQuery } from '../lib/fonts/compare-context'
 
+const PAGE_SIZE = 512
+
 const props = defineProps({
   blockSlug: { type: String, required: true }
 })
@@ -16,10 +18,27 @@ const fontSlugs = computed(() => parseFontSlugsFromQuery((typeof window !== 'und
 const block = ref<UnicodeBlock | null>(null)
 const characters = ref<any[]>([])
 const fontContexts = ref<FontContext[]>([])
+const currentPage = ref(1)
+
+const totalPages = computed(() => Math.max(1, Math.ceil(characters.value.length / PAGE_SIZE)))
+
+const pagedCharacters = computed(() => {
+  const start = (currentPage.value - 1) * PAGE_SIZE
+  return characters.value.slice(start, start + PAGE_SIZE)
+})
+
+const pageStartCp = computed(() => {
+  if (!block.value || pagedCharacters.value.length === 0) return ''
+  return hexCp(pagedCharacters.value[0].cp)
+})
+const pageEndCp = computed(() => {
+  if (!block.value || pagedCharacters.value.length === 0) return ''
+  return hexCp(pagedCharacters.value[pagedCharacters.value.length - 1].cp)
+})
 
 const blockWithChars = computed(() =>
   block.value
-    ? { ...block.value, characters: characters.value, assignedCount: characters.value.length }
+    ? { ...block.value, characters: pagedCharacters.value, assignedCount: characters.value.length }
     : null
 )
 
@@ -47,6 +66,10 @@ async function loadData() {
   } else {
     fontContexts.value = []
   }
+
+  const pageParam = typeof window !== 'undefined' ? new URLSearchParams(window.location.search).get('page') : null
+  const p = pageParam ? parseInt(pageParam, 10) : 1
+  currentPage.value = (isNaN(p) || p < 1) ? 1 : Math.min(p, totalPages.value)
 }
 
 await loadData()
@@ -57,6 +80,25 @@ const compareTitle = computed(() => {
   return fontContexts.value.map(f => f.familyName).join(' · ')
 })
 
+const pageWindow = computed(() => {
+  const pages: number[] = []
+  const start = Math.max(1, currentPage.value - 2)
+  const end = Math.min(totalPages.value, currentPage.value + 2)
+  for (let i = start; i <= end; i++) pages.push(i)
+  return pages
+})
+
+function goToPage(page: number) {
+  currentPage.value = page
+  const el = document.querySelector('.ubp')
+  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  if (typeof window !== 'undefined') {
+    const url = new URL(window.location.href)
+    if (page > 1) url.searchParams.set('page', String(page))
+    else url.searchParams.delete('page')
+    window.history.replaceState({}, '', url)
+  }
+}
 
 function goToChar(cp: number) {
   window.location.href = charRoute(cp)
@@ -104,20 +146,89 @@ function goToChar(cp: number) {
       </p>
     </div>
 
-    <UnicodeBlockGrid
-      v-else-if="blockWithChars"
-      :block="blockWithChars"
-      :fonts="fontContexts"
-      :mode="gridMode"
-      :show-missing="true"
-      :max-chars="10000"
-      @select="goToChar"
-    />
+    <template v-else-if="blockWithChars">
+      <div v-if="totalPages > 1" class="ubp-page-info">
+        Page {{ currentPage }} of {{ totalPages }} · {{ pageStartCp }}–{{ pageEndCp }}
+      </div>
+
+      <UnicodeBlockGrid
+        :block="blockWithChars"
+        :fonts="fontContexts"
+        :mode="gridMode"
+        :show-missing="true"
+        :max-chars="PAGE_SIZE"
+        @select="goToChar"
+      />
+
+      <nav v-if="totalPages > 1" class="ubp-pagination">
+        <button class="ubp-page-btn" :disabled="currentPage === 1" @click="goToPage(currentPage - 1)">← Prev</button>
+        <button v-if="pageWindow[0] > 1" class="ubp-page-btn" @click="goToPage(1)">1</button>
+        <span v-if="pageWindow[0] > 2" class="ubp-page-ellipsis">…</span>
+        <button
+          v-for="page in pageWindow"
+          :key="page"
+          :class="['ubp-page-btn', { on: page === currentPage }]"
+          @click="goToPage(page)"
+        >{{ page }}</button>
+        <span v-if="pageWindow[pageWindow.length - 1] < totalPages - 1" class="ubp-page-ellipsis">…</span>
+        <button v-if="pageWindow[pageWindow.length - 1] < totalPages" class="ubp-page-btn" @click="goToPage(totalPages)">{{ totalPages }}</button>
+        <button class="ubp-page-btn" :disabled="currentPage === totalPages" @click="goToPage(currentPage + 1)">Next →</button>
+      </nav>
+    </template>
   </div>
 
   <div v-else class="ubp-loading">Block "{{ blockSlugParam }}" not found.</div>
 </template>
 
 <style scoped>
-/* All styles migrated to src/styles/main.css (@layer components). */
+.ubp-page-info {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--color-mute);
+  margin-bottom: 1rem;
+  padding: 0.5rem 0;
+}
+
+.ubp-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  padding: 2rem 0;
+  margin-top: 1rem;
+  flex-wrap: wrap;
+}
+
+.ubp-page-btn {
+  background: transparent;
+  border: 1px solid var(--color-rule);
+  border-radius: 2px;
+  padding: 0.35rem 0.7rem;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--color-ink-soft);
+  cursor: pointer;
+  transition: all 0.15s;
+  min-width: 32px;
+}
+.ubp-page-btn:hover:not(:disabled):not(.on) {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+.ubp-page-btn.on {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-paper);
+}
+.ubp-page-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.ubp-page-ellipsis {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--color-mute);
+  padding: 0 0.3rem;
+}
 </style>


### PR DESCRIPTION
## Summary

Large blocks like CJK Extension B (42,720 codepoints), CJK Unified Ideographs (20,992), and Hangul Syllables (11,184) were either silently truncated at 10,000 chars or rendered as massive DOM trees that froze the browser.

Now paginates at **512 characters per page**:
- Reads `?page=N` from URL query param
- Page info shows "Page X of Y · U+START–U+END" for the current page range
- Page window navigation (prev/next + numbered pages + ellipsis)
- URL syncs on page change (replaceState, no full reload)
- Smooth scroll to top on page navigation
- 512 cells keeps DOM light vs 10,000+

Same editorial pagination styling as families/formulas browsers.

## Test plan

- [x] Build succeeds (63 pages)
- [ ] CI passes