### PR TITLE
fix: Essenfont not loading — fetch script now downloads woff2 files in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "scripts": {
     "dev": "astro dev",
-    "build": "bash scripts/fetch-data.sh && node scripts/enrich-font-metadata.mjs && node scripts/gen-font-families.mjs && node scripts/gen-licenses-index.mjs && node scripts/gen-blog-index.mjs && node scripts/gen-guide-index.mjs && astro build && node scripts/gen-sitemap.mjs",
-    "build:no-fetch": "node scripts/enrich-font-metadata.mjs && node scripts/gen-font-families.mjs && node scripts/gen-licenses-index.mjs && node scripts/gen-blog-index.mjs && node scripts/gen-guide-index.mjs && astro build && node scripts/gen-sitemap.mjs",
+    "build": "bash scripts/fetch-data.sh && node scripts/fetch-essenfont.mjs && node scripts/enrich-font-metadata.mjs && node scripts/gen-font-families.mjs && node scripts/gen-licenses-index.mjs && node scripts/gen-blog-index.mjs && node scripts/gen-guide-index.mjs && astro build && node scripts/gen-sitemap.mjs",
+    "build:no-fetch": "node scripts/fetch-essenfont.mjs && node scripts/enrich-font-metadata.mjs && node scripts/gen-font-families.mjs && node scripts/gen-licenses-index.mjs && node scripts/gen-blog-index.mjs && node scripts/gen-guide-index.mjs && astro build && node scripts/gen-sitemap.mjs",
     "preview": "astro preview",
     "fetch-data": "bash scripts/fetch-data.sh",
     "gen-routes": "node scripts/gen-blog-index.mjs && node scripts/gen-guide-index.mjs ",

--- a/scripts/fetch-essenfont.mjs
+++ b/scripts/fetch-essenfont.mjs
@@ -1,16 +1,15 @@
 #!/usr/bin/env node
-// Downloads Essenfont per-block WOFF2 files + generates fonts.css.
+// Downloads Essenfont per-block WOFF2 files from the essenfont.github.io
+// repo and generates fonts.css with @font-face rules using unicode-range.
 //
-// Essenfont covers ALL assigned Unicode codepoints. The fonts are split
-// by Unicode block (~214 files). The browser only fetches subsets for
-// characters actually rendered on the page (via unicode-range in @font-face).
+// Essenfont covers ALL assigned Unicode codepoints. The browser only fetches
+// subsets for characters actually rendered (via unicode-range in @font-face).
 //
-// Source: https://www.essenfont.org (GitHub: essenfont/essenfont.github.io)
-//
-// Run as part of scripts/fetch-data.sh or standalone.
+// Run as part of the build pipeline (after fetch-data.sh, before astro build).
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, copyFileSync, rmSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
+import { execSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -18,15 +17,45 @@ const ROOT = resolve(__dirname, '..')
 const PUBLIC = resolve(ROOT, 'public')
 const FONTS_DIR = resolve(PUBLIC, 'fonts')
 
-// Essenfont GitHub raw URLs
-const ESSENFONT_BASE = 'https://raw.githubusercontent.com/essenfont/essenfont.github.io/main/public'
+const ESSENFONT_REPO = 'https://github.com/essenfont/essenfont.github.io.git'
 
 if (!existsSync(FONTS_DIR)) mkdirSync(FONTS_DIR, { recursive: true })
 
-// Read the unicode blocks to know which font files to fetch
+// ── Step 1: Clone essenfont.github.io and copy font files ──
+
+const hasFonts = existsSync(FONTS_DIR) && readdirSync(FONTS_DIR).some(f => f.endsWith('.woff2') && !f.startsWith('noto'))
+
+if (!hasFonts) {
+  console.log('Essenfont: cloning essenfont.github.io (shallow)...')
+  try {
+    const tmp = execSync('mktemp -d').toString().trim()
+    execSync(`git clone --depth 1 ${ESSENFONT_REPO} ${tmp}/essenfont`, { stdio: 'pipe', timeout: 120000 })
+
+    const srcFontsDir = `${tmp}/essenfont/public/fonts`
+    if (existsSync(srcFontsDir)) {
+      let copied = 0
+      for (const file of readdirSync(srcFontsDir)) {
+        if (file.endsWith('.woff2') && !file.startsWith('Essenfont-') && !file.startsWith('noto')) {
+          copyFileSync(`${srcFontsDir}/${file}`, `${FONTS_DIR}/${file}`)
+          copied++
+        }
+      }
+      console.log(`Essenfont: copied ${copied} per-block woff2 files`)
+    }
+
+    rmSync(tmp, { recursive: true, force: true })
+  } catch (e) {
+    console.log('Essenfont: clone failed, skipping —', String(e).slice(0, 200))
+  }
+} else {
+  console.log('Essenfont: woff2 files already present, skipping clone')
+}
+
+// ── Step 2: Generate fonts.css from unicode-blocks.json ──
+
 const blocksPath = resolve(PUBLIC, 'unicode-blocks.json')
 if (!existsSync(blocksPath)) {
-  console.log('unicode-blocks.json not found — skipping Essenfont fetch')
+  console.log('Essenfont: unicode-blocks.json not found, cannot generate fonts.css')
   process.exit(0)
 }
 
@@ -36,47 +65,44 @@ function blockSlug(name) {
   return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
 }
 
-// Non-graphic blocks that produce degenerate fonts — skip these
-const NON_GRAPHIC = new Set(['tags', 'private-use-area', 'supplementary-private-use-area-a', 'supplementary-private-use-area-b'])
+const NON_GRAPHIC = new Set([
+  'tags', 'private-use-area',
+  'supplementary-private-use-area-a', 'supplementary-private-use-area-b',
+])
 
 function hexCp(cp) {
   return cp.toString(16).toUpperCase().padStart(4, '0')
 }
 
-let fetched = 0
-let skipped = 0
 const cssRules = []
+let available = 0
+let missing = 0
 
 for (const block of blocks) {
   const slug = blockSlug(block.name)
-  if (NON_GRAPHIC.has(slug)) {
-    skipped++
-    continue
-  }
+  if (NON_GRAPHIC.has(slug)) continue
 
-  const localPath = resolve(FONTS_DIR, `${slug}.woff2`)
+  const woff2Path = resolve(FONTS_DIR, `${slug}.woff2`)
+  if (!existsSync(woff2Path)) { missing++; continue }
 
-  if (!existsSync(localPath)) {
-    // Would fetch here in CI. For now, just note it's missing.
-    skipped++
-    continue
-  }
-
-  fetched++
-  const start = hexCp(block.start)
-  const end = hexCp(block.end)
+  available++
   cssRules.push(`@font-face {
   font-family: "Essenfont";
   src: url("/fonts/${slug}.woff2") format("woff2");
   font-weight: 100 900;
   font-style: normal;
   font-display: swap;
-  unicode-range: U+${start}-${end};
+  unicode-range: U+${hexCp(block.start)}-${hexCp(block.end)};
 }`)
 }
 
-console.log(`Essenfont: ${fetched} block fonts available, ${skipped} skipped`)
+console.log(`Essenfont: ${available} block fonts available, ${missing} missing`)
+
+if (cssRules.length === 0) {
+  console.log('Essenfont: no font files found, skipping fonts.css')
+  process.exit(0)
+}
 
 const cssPath = resolve(PUBLIC, 'fonts.css')
 writeFileSync(cssPath, cssRules.join('\n\n') + '\n')
-console.log(`Wrote ${cssPath} (${cssRules.length} @font-face rules)`)
+console.log(`Essenfont: wrote fonts.css (${cssRules.length} @font-face rules)`)


### PR DESCRIPTION
## Summary

Essenfont wasn't loading on the live site because:

1. `fetch-esenfont.mjs` didn't actually download anything — it just scanned local files and had a comment saying "Would fetch here in CI"
2. The script was not in the CI build pipeline

Result: `/fonts.css` was a 404 on the live site, so no Essenfont @font-face rules loaded, so Unicode block pages showed tofu for non-Latin scripts (Mayan numerals, Gothic, Arabic Extended-C, etc.).

**Fix:** `fetch-essenfont.mjs` now clones `essenfont/essenfont.github.io` and copies per-block woff2 files. Added to both `build` and `build:no-fetch` scripts, before `enrich-font-metadata.mjs`.

## Test plan

- [x] Build succeeds (63 pages)
- [x] fonts.css with 209 @font-face rules generated
- [ ] CI passes (this PR will be the first CI run that actually downloads Essenfont)