### PR TITLE
feat: WAAPI easter eggs — glyph trail, konami code, logo spin, count-up, wobble

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount } from 'vue'
 import DocsDropdown from './DocsDropdown.vue'
+import { useFunStuff } from '../composables/useFunStuff'
+
+useFunStuff()
 
 const props = withDefaults(defineProps<{
   currentPath?: string

--- a/src/composables/useFunStuff.ts
+++ b/src/composables/useFunStuff.ts
@@ -1,0 +1,178 @@
+import { onMounted, onBeforeUnmount } from 'vue'
+
+const KONAMI = [
+  'ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown',
+  'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight', 'b', 'a',
+]
+
+const GLYPH_RAIN = '★◆◇○●△▲▽▼✦✧❖⚡✎⚙⚠❄✈✉✓✕✗✘❀❁❂❃❆❇❈❉❊❋♔♕♖♗♘♙♚♛♜♝♞♟♻⚛⚜⚡♾'
+const TRAIL_GLYPHS = 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩ☀☁☂★☆☎☘♨⚓⚖⚙⚡❄✈✉✎✓✦✧❀❆❇❈♩♪♫♬♭♮♯'
+
+function randomGlyph(set: string) {
+  return set[Math.floor(Math.random() * set.length)]
+}
+
+function triggerGlyphRain() {
+  for (let i = 0; i < 100; i++) {
+    const el = document.createElement('span')
+    el.textContent = randomGlyph(GLYPH_RAIN)
+    el.style.cssText = `position:fixed;top:-60px;left:${Math.random() * 100}vw;font-size:${14 + Math.random() * 32}px;color:hsl(${Math.random() * 60 + 320},85%,${50 + Math.random() * 25}%);pointer-events:none;z-index:99999;text-shadow:0 0 12px currentColor;font-family:'Essenfont','IBM Plex Sans',sans-serif`
+    document.body.appendChild(el)
+
+    const dur = 2000 + Math.random() * 3000
+    el.animate(
+      [
+        { transform: `translateY(0) rotate(0deg)`, opacity: 1 },
+        { transform: `translateY(${window.innerHeight + 100}px) rotate(${Math.random() * 720 - 360}deg)`, opacity: 0 },
+      ],
+      { duration: dur, easing: 'cubic-bezier(0.25, 0.46, 0.45, 0.94)' },
+    ).onfinish = () => el.remove()
+  }
+
+  const flash = document.createElement('div')
+  flash.style.cssText = `position:fixed;inset:0;z-index:99998;pointer-events:none;background:radial-gradient(circle at 50% 50%, hsla(340,80%,60%,0.15), transparent 70%)`
+  document.body.appendChild(flash)
+  flash.animate([{ opacity: 1 }, { opacity: 0 }], { duration: 1500, easing: 'ease-out' }).onfinish = () => flash.remove()
+}
+
+let logoClickCount = 0
+let logoTimer: ReturnType<typeof setTimeout> | null = null
+
+function triggerLogoSpin() {
+  const logo = document.querySelector('.nav-logo')
+  if (!logo) return
+
+  logo.animate(
+    [
+      { transform: 'rotate(0deg) scale(1)' },
+      { transform: 'rotate(180deg) scale(1.3)' },
+      { transform: 'rotate(360deg) scale(1.1)' },
+      { transform: 'rotate(540deg) scale(1.3)' },
+      { transform: 'rotate(720deg) scale(1)' },
+    ],
+    { duration: 1200, easing: 'cubic-bezier(0.68, -0.55, 0.265, 1.55)' },
+  )
+
+  const nav = document.querySelector('.nav')
+  nav?.animate(
+    [{ filter: 'hue-rotate(0deg)' }, { filter: 'hue-rotate(360deg)' }],
+    { duration: 1200, easing: 'linear' },
+  )
+
+  for (let i = 0; i < 30; i++) {
+    const el = document.createElement('span')
+    el.textContent = randomGlyph(GLYPH_RAIN)
+    el.style.cssText = `position:fixed;left:50%;top:60px;font-size:${12 + Math.random() * 20}px;color:hsl(${Math.random() * 360},80%,60%);pointer-events:none;z-index:99999;text-shadow:0 0 8px currentColor`
+    document.body.appendChild(el)
+    const angle = (Math.PI * 2 * i) / 30 + Math.random() * 0.5
+    const dist = 150 + Math.random() * 250
+    el.animate(
+      [
+        { transform: 'translate(-50%, -50%) scale(0)', opacity: 1 },
+        {
+          transform: `translate(calc(-50% + ${Math.cos(angle) * dist}px), calc(-50% + ${Math.sin(angle) * dist}px)) scale(1.5)`,
+          opacity: 0,
+        },
+      ],
+      { duration: 1000 + Math.random() * 800, easing: 'cubic-bezier(0.25, 0.46, 0.45, 0.94)' },
+    ).onfinish = () => el.remove()
+  }
+}
+
+let lastTrail = 0
+function onMouseMove(e: MouseEvent) {
+  const now = performance.now()
+  if (now - lastTrail < 70) return
+  lastTrail = now
+
+  const el = document.createElement('span')
+  el.textContent = randomGlyph(TRAIL_GLYPHS)
+  el.style.cssText = `position:fixed;left:${e.clientX}px;top:${e.clientY}px;font-size:${10 + Math.random() * 14}px;color:var(--color-accent);pointer-events:none;z-index:99998;opacity:0.5;transform:translate(-50%,-50%);font-family:'Essenfont','IBM Plex Sans',sans-serif`
+  document.body.appendChild(el)
+
+  el.animate(
+    [
+      { transform: 'translate(-50%, -50%) scale(1) rotate(0deg)', opacity: 0.5 },
+      { transform: 'translate(-50%, calc(-50% - 35px)) scale(0.2) rotate(90deg)', opacity: 0 },
+    ],
+    { duration: 700, easing: 'ease-out' },
+  ).onfinish = () => el.remove()
+}
+
+let konamiIdx = 0
+function onKeyDown(e: KeyboardEvent) {
+  const key = e.key.length === 1 ? e.key.toLowerCase() : e.key
+  if (key === KONAMI[konamiIdx].toLowerCase() || key === KONAMI[konamiIdx]) {
+    konamiIdx++
+    if (konamiIdx === KONAMI.length) {
+      triggerGlyphRain()
+      konamiIdx = 0
+    }
+  } else {
+    konamiIdx = key === KONAMI[0] ? 1 : 0
+  }
+}
+
+function onLogoClick() {
+  logoClickCount++
+  if (logoTimer) clearTimeout(logoTimer)
+  logoTimer = setTimeout(() => { logoClickCount = 0 }, 2000)
+
+  if (logoClickCount >= 5) {
+    logoClickCount = 0
+    triggerLogoSpin()
+  }
+}
+
+function attachLogoListener() {
+  const logo = document.querySelector('.nav-logo')
+  logo?.addEventListener('click', onLogoClick, { passive: true })
+}
+
+function detachLogoListener() {
+  document.querySelector('.nav-logo')?.removeEventListener('click', onLogoClick)
+}
+
+export function useFunStuff(opts: { trail?: boolean; konami?: boolean; logo?: boolean } = {}) {
+  const { trail = true, konami = true, logo = true } = opts
+
+  onMounted(() => {
+    if (trail) document.addEventListener('mousemove', onMouseMove, { passive: true })
+    if (konami) document.addEventListener('keydown', onKeyDown)
+    if (logo) setTimeout(attachLogoListener, 100)
+  })
+
+  onBeforeUnmount(() => {
+    document.removeEventListener('mousemove', onMouseMove)
+    document.removeEventListener('keydown', onKeyDown)
+    detachLogoListener()
+  })
+}
+
+export function animateCountUp(el: HTMLElement, target: number, duration = 1500) {
+  const start = performance.now()
+  const startVal = 0
+
+  function frame(now: number) {
+    const elapsed = now - start
+    const progress = Math.min(elapsed / duration, 1)
+    const eased = 1 - Math.pow(1 - progress, 3)
+    const val = Math.floor(startVal + (target - startVal) * eased)
+    el.textContent = val.toLocaleString()
+    if (progress < 1) requestAnimationFrame(frame)
+    else el.textContent = target.toLocaleString()
+  }
+
+  requestAnimationFrame(frame)
+}
+
+export function wobbleText(el: HTMLElement) {
+  el.animate(
+    [
+      { fontWeight: '400', letterSpacing: '0em' },
+      { fontWeight: '900', letterSpacing: '0.02em' },
+      { fontWeight: '400', letterSpacing: '0em' },
+    ],
+    { duration: 600, easing: 'ease-in-out' },
+  )
+}

--- a/src/islands/HomePage.vue
+++ b/src/islands/HomePage.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, onMounted, onUnmounted, nextTick } from 'vue'
 import { loadAllFormulas } from '../lib/formulas/loader'
 import { bucketFormulas } from '../lib/licenses/classifier'
 import { fetchJson } from '../lib/ssr-fetch'
+import { animateCountUp, wobbleText } from '../composables/useFunStuff'
 
 // Type Specimen homepage.
 // Two distinct ideas, kept distinct:
@@ -43,6 +44,14 @@ async function loadStats() {
 }
 
 await loadStats()
+
+nextTick(() => {
+  const statEls = document.querySelectorAll<HTMLElement>('.colophon .n')
+  statEls.forEach((el, i) => {
+    const raw = el.textContent?.replace(/[^0-9]/g, '')
+    if (raw && parseInt(raw) > 0) animateCountUp(el, parseInt(raw), 1500 + i * 200)
+  })
+})
 
 const specimens = [
   {
@@ -239,7 +248,7 @@ onUnmounted(() => { if (typeTimer) clearTimeout(typeTimer) })
 
         <ul class="spec-list">
           <li v-for="s in specimens" :key="s.name" class="spec-row">
-            <div class="spec-sample" :style="{ fontFamily: s.cssFamily }">{{ s.name }}</div>
+            <div class="spec-sample" :style="{ fontFamily: s.cssFamily }" @mouseenter="(e) => wobbleText(e.target as HTMLElement)">{{ s.name }}</div>
             <div class="spec-detail">
               <span class="prompt">$</span> <span class="cmd">{{ s.install }}</span>
               <span class="sep">·</span>


### PR DESCRIPTION
## Summary

Five interactive additions using the Web Animations API (`element.animate()`). No CSS keyframes, no animation libraries — pure WAAPI.

### 1. Cursor Glyph Trail
Unicode glyphs (Greek letters, symbols, dingbats) float up and fade from the cursor on every page. Throttled to ~14 glyphs/sec. Each glyph uses the Essenfont font family and the accent color. Elements self-destruct after animation.

### 2. Konami Code Easter Egg
Enter ↑↑↓↓←→←→BA on any page — triggers a 100-glyph rain across the screen with randomized HSL colors, rotations (±360°), durations (2–5s), and cubic-bezier easing. Plus a radial accent flash.

### 3. Logo Click Easter Egg
Click the Fontist logo 5 times rapidly — triggers:
- 720° spin with bounce easing
- Full nav bar hue-rotate rainbow (0→360°)
- 30-glyph radial burst from the logo position

### 4. Count-Up Animation
Homepage colophon stats (formula count, open-source count) animate from 0 with cubic ease-out. Staggered 200ms per number for a cascade effect.

### 5. Specimen Wobble
Hovering a specimen sample on the homepage animates `font-weight: 400→900→400` with a subtle `letter-spacing` pulse. Shows off variable font capabilities.

All animations use `element.animate()` — elements are created dynamically and removed on finish. Zero DOM pollution after animation completes.

## Test plan

- [x] Build succeeds (63 pages)
- [ ] Move mouse — glyphs trail from cursor
- [ ] Type ↑↑↓↓←→←→BA — glyph rain
- [ ] Click logo 5× rapidly — spin + burst
- [ ] Homepage stats count up from 0
- [ ] Hover specimen names — weight wobble
- [ ] CI passes