### PR TITLE
fix: 5-click trigger on footer diamond, cursor trail homepage-only

### DIFF
--- a/src/composables/useFunStuff.ts
+++ b/src/composables/useFunStuff.ts
@@ -125,16 +125,16 @@ function onLogoClick() {
 }
 
 function attachLogoListener() {
-  const logo = document.querySelector('.nav-logo')
-  logo?.addEventListener('click', onLogoClick, { passive: true })
+  const diamond = document.querySelector('.sf-rule-mark')
+  diamond?.addEventListener('click', onLogoClick)
 }
 
 function detachLogoListener() {
-  document.querySelector('.nav-logo')?.removeEventListener('click', onLogoClick)
+  document.querySelector('.sf-rule-mark')?.removeEventListener('click', onLogoClick)
 }
 
 export function useFunStuff(opts: { trail?: boolean; konami?: boolean; logo?: boolean } = {}) {
-  const { trail = true, konami = true, logo = true } = opts
+  const { trail = false, konami = true, logo = true } = opts
 
   onMounted(() => {
     if (trail) document.addEventListener('mousemove', onMouseMove, { passive: true })

--- a/src/islands/HomePage.vue
+++ b/src/islands/HomePage.vue
@@ -4,6 +4,9 @@ import { loadAllFormulas } from '../lib/formulas/loader'
 import { bucketFormulas } from '../lib/licenses/classifier'
 import { fetchJson } from '../lib/ssr-fetch'
 import { animateCountUp, wobbleText } from '../composables/useFunStuff'
+import { useFunStuff } from '../composables/useFunStuff'
+
+useFunStuff({ trail: true, konami: false, logo: false })
 
 // Type Specimen homepage.
 // Two distinct ideas, kept distinct:


### PR DESCRIPTION
## Summary

1. **5-click trigger moved to footer diamond** — the logo is an `<a href='/'\>`, so clicking it navigates away before 5 clicks accumulate. Moved to the footer's decorative `◆` mark (`.sf-rule-mark`), which is non-navigating and thematically perfect.

2. **Cursor trail is now homepage-only** — it was annoying on functional pages (formulas browse, families browse, unicode browser). NavBar now calls `useFunStuff()` with trail disabled by default. HomePage explicitly enables it via `useFunStuff({ trail: true, konami: false, logo: false })`.

## Test plan

- [x] Build succeeds
- [ ] Homepage: cursor trail works
- [ ] Other pages: no cursor trail
- [ ] Click footer ◆ 5× rapidly: spin + burst
- [ ] CI passes